### PR TITLE
Scale composite emoji actors with dominant part

### DIFF
--- a/components/AnimationTypes.ts
+++ b/components/AnimationTypes.ts
@@ -29,6 +29,10 @@ export type CompositeActor = {
   loop?: 'float' | 'none';
   z?: number;
   ariaLabel?: string;
+  meta?: {
+    /** Overrides automatic group sizing in pixels for manual tuning */
+    sizeOverride?: number;
+  };
 };
 
 export type Actor = EmojiActor | CompositeActor;


### PR DESCRIPTION
## Summary
- compute composite actor bounding boxes and scale using largest part
- allow manual size tuning via `meta.sizeOverride`

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: OPENAI_API_KEY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5368389c48326a04c6fa06079c4be