### PR TITLE
Make storyboard prompts configurable

### DIFF
--- a/lib/prompt/buildStoryboardPrompt.ts
+++ b/lib/prompt/buildStoryboardPrompt.ts
@@ -1,11 +1,15 @@
-export const EFFECTS_SYSTEM_PROMPT = `You support the following visual effects that run at scene start and may be applied to scenes or actors via an \"effects\" array:
-- \"fade-in\": actor fades in from transparent.
-- \"bounce\": actor enters with a springy bounce.
-Use only these names. Add effects when they enhance the story; omit otherwise.`;
+import { PromptConfig } from './config';
 
-export const STORYBOARD_PROMPT = `You convert a short story into an animated storyboard JSON.
+export function buildStoryboardPrompt(config: PromptConfig) {
+  const effectsList = config.effects
+    .map((e) => `- "${e.name}": ${e.description}`)
+    .join('\n');
+
+  const systemPrompt = `You support the following visual effects that run at scene start and may be applied to scenes or actors via an "effects" array:\n${effectsList}\nUse only these names. Add effects when they enhance the story; omit otherwise.`;
+
+  const storyboardPrompt = `You convert a short story into an animated storyboard JSON.
 Constraints:
-- Max 10 scenes, max 5 actors per scene, total duration <= 90000 ms.
+- Max ${config.maxScenes} scenes, max ${config.maxActorsPerScene} actors per scene, total duration <= ${config.maxTotalDurationMs} ms.
 - Use Unicode emoji for actors (type: 'emoji') or composite actors (type: 'composite' with "parts" listing emoji actors that move together).
 - Coordinates x,y are normalized 0..1.
 - For composite actors, each part has its own {x,y,scale} offset; always specify scale to reflect realistic proportions (e.g., a horse larger than its rider).
@@ -14,7 +18,9 @@ Constraints:
 - Keyframes are in ms relative to the scene.
 - The caption is used to tell the story and what the actual scene tells about the story
 - Each scene can include backgroundActors (array of emoji actors) rendered behind foreground actors. The background actors are the things that define the scene, it cannot be an active actor playing in the scene! It always needs a background buildt out of background actors. Choose backgrounds that match the setting and use generous scales (roughly 2-5) so they anchor the scene without overwhelming it.
-- When relevant, include an \"effects\" array using the effect names defined in the system prompt.
+- When relevant, include an "effects" array using the effect names defined in the system prompt.
 Output ONLY valid JSON that matches the types: Keyframe, EmojiActor, Actor, Scene, Animation.
 Ensure final keyframes align with each scene's duration. No prose, no markdown; JSON only.`;
 
+  return { systemPrompt, storyboardPrompt };
+}

--- a/lib/prompt/config.ts
+++ b/lib/prompt/config.ts
@@ -1,0 +1,21 @@
+export interface EffectConfig {
+  name: string;
+  description: string;
+}
+
+export interface PromptConfig {
+  maxScenes: number;
+  maxActorsPerScene: number;
+  maxTotalDurationMs: number;
+  effects: readonly EffectConfig[];
+}
+
+export const defaultPromptConfig: PromptConfig = {
+  maxScenes: 10,
+  maxActorsPerScene: 5,
+  maxTotalDurationMs: 90_000,
+  effects: [
+    { name: 'fade-in', description: 'actor fades in from transparent.' },
+    { name: 'bounce', description: 'actor enters with a springy bounce.' },
+  ] as const,
+};


### PR DESCRIPTION
## Summary
- add PromptConfig interface and default configuration for storyboard limits and effects
- build storyboard prompts dynamically from PromptConfig
- update storyboard API route to assemble prompts from configuration

## Testing
- `npx next lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b58c67be948326bbdd65f13e0fd0e9