### PR TITLE
Add Supabase auth and movie storage

### DIFF
--- a/Supabase.sql
+++ b/Supabase.sql
@@ -1,0 +1,22 @@
+create table if not exists public.movies (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id),
+  title text,
+  story text,
+  animation jsonb,
+  created_at timestamptz default now()
+);
+
+alter table public.movies enable row level security;
+
+create policy "Public read access" on public.movies
+  for select using (true);
+
+create policy "Users can insert their own movies" on public.movies
+  for insert with check (auth.uid() = user_id);
+
+create policy "Users can update their own movies" on public.movies
+  for update using (auth.uid() = user_id);
+
+create policy "Users can delete their own movies" on public.movies
+  for delete using (auth.uid() = user_id);

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { signIn } from '../../../lib/supabaseClient';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      await signIn(email, password);
+      router.push('/movies');
+    } catch (err: any) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto py-8">
+      <h1 className="text-2xl font-bold mb-4 text-center">Login</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          className="p-2 border rounded"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          className="p-2 border rounded"
+          required
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button type="submit" className="bg-blue-600 text-white py-2 rounded">Login</button>
+      </form>
+    </div>
+  );
+}
+

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { signUp } from '../../../lib/supabaseClient';
+
+export default function RegisterPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      await signUp(email, password);
+      router.push('/movies');
+    } catch (err: any) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto py-8">
+      <h1 className="text-2xl font-bold mb-4 text-center">Register</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          className="p-2 border rounded"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          className="p-2 border rounded"
+          required
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button type="submit" className="bg-blue-600 text-white py-2 rounded">Register</button>
+      </form>
+    </div>
+  );
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import './globals.css';
+import { Navbar } from '../components/Navbar';
 
 export const metadata = {
   title: 'Emoji Movie MVP',
@@ -10,6 +11,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className="min-h-screen bg-gray-50 text-gray-900">
+        <Navbar />
         {children}
       </body>
     </html>

--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getMoviesByUser } from '../../lib/supabaseClient';
+import type { Animation } from '../../components/AnimationTypes';
+import { EmojiPlayer } from '../../components/EmojiPlayer';
+
+export default function MoviesPage() {
+  const [movies, setMovies] = useState<any[]>([]);
+  const [selected, setSelected] = useState<any | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getMoviesByUser()
+      .then(setMovies)
+      .catch(e => setError(e.message));
+  }, []);
+
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-4 text-center">My Movies</h1>
+      {error && <p className="text-red-600 text-center">{error}</p>}
+      <ul className="mb-8 space-y-2">
+        {movies.map(m => (
+          <li key={m.id} className="flex justify-between items-center border p-2 rounded">
+            <span>{m.title || m.story.slice(0,30)}</span>
+            <button onClick={() => setSelected(m)} className="text-blue-600 underline">Play</button>
+          </li>
+        ))}
+      </ul>
+      {selected && (
+        <div className="flex justify-center">
+          <EmojiPlayer animation={selected.animation as Animation} width={600} height={300} />
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { getUser, signOut } from '../lib/supabaseClient';
+
+export function Navbar() {
+  const [user, setUser] = useState<any>(null);
+
+  useEffect(() => {
+    getUser().then(setUser);
+  }, []);
+
+  async function handleSignOut() {
+    await signOut();
+    setUser(null);
+  }
+
+  return (
+    <nav className="bg-white shadow p-4 flex justify-between">
+      <Link href="/" className="font-bold">Emoji Movie Studio</Link>
+      <div className="flex gap-4 items-center">
+        {user ? (
+          <>
+            <Link href="/movies" className="underline">My Movies</Link>
+            <button onClick={handleSignOut} className="text-sm text-red-600">Logout</button>
+          </>
+        ) : (
+          <>
+            <Link href="/auth/login" className="underline">Login</Link>
+            <Link href="/auth/register" className="underline">Register</Link>
+          </>
+        )}
+      </div>
+    </nav>
+  );
+}
+

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,101 +1,55 @@
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+import { createBrowserClient } from '@supabase/ssr';
 
-function getToken() {
-  if (typeof window === 'undefined') return null;
-  return localStorage.getItem('sb-access-token');
-}
-
-function setToken(token: string | null) {
-  if (typeof window === 'undefined') return;
-  if (token) localStorage.setItem('sb-access-token', token);
-  else localStorage.removeItem('sb-access-token');
-}
-
-async function authRequest(path: string, body: any) {
-  const res = await fetch(`${SUPABASE_URL}/auth/v1/${path}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      apikey: SUPABASE_ANON_KEY,
-    },
-    body: JSON.stringify(body),
-  });
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.error?.message || 'Auth error');
-  if (data.session?.access_token) setToken(data.session.access_token);
-  if (data.access_token) setToken(data.access_token);
-  return data;
-}
+const supabase = createBrowserClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
 
 export async function signUp(email: string, password: string) {
-  return authRequest('signup', { email, password });
+  const { error } = await supabase.auth.signUp({ email, password });
+  if (error) throw error;
 }
 
 export async function signIn(email: string, password: string) {
-  return authRequest('token?grant_type=password', { email, password });
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) throw error;
 }
 
 export async function signOut() {
-  setToken(null);
+  const { error } = await supabase.auth.signOut();
+  if (error) throw error;
 }
 
 export async function getUser() {
-  const token = getToken();
-  if (!token) return null;
-  const res = await fetch(`${SUPABASE_URL}/auth/v1/user`, {
-    headers: {
-      apikey: SUPABASE_ANON_KEY,
-      Authorization: `Bearer ${token}`,
-    },
-  });
-  if (!res.ok) return null;
-  const data = await res.json();
+  const { data, error } = await supabase.auth.getUser();
+  if (error) return null;
   return data.user;
 }
 
 export async function insertMovie(movie: { title: string; story: string; animation: any; }) {
-  const token = getToken();
-  if (!token) throw new Error('Not authenticated');
   const user = await getUser();
   if (!user) throw new Error('Not authenticated');
-  const res = await fetch(`${SUPABASE_URL}/rest/v1/movies`, {
-    method: 'POST',
-    headers: {
-      apikey: SUPABASE_ANON_KEY,
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-      Prefer: 'return=representation',
-    },
-    body: JSON.stringify({
+  const { data, error } = await supabase
+    .from('movies')
+    .insert({
       user_id: user.id,
       title: movie.title,
       story: movie.story,
       animation: movie.animation,
-    }),
-  });
-  if (!res.ok) {
-    const err = await res.text();
-    throw new Error(err);
-  }
-  return res.json();
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
 }
 
 export async function getMoviesByUser() {
-  const token = getToken();
-  if (!token) throw new Error('Not authenticated');
   const user = await getUser();
   if (!user) throw new Error('Not authenticated');
-  const res = await fetch(`${SUPABASE_URL}/rest/v1/movies?user_id=eq.${user.id}&select=*`, {
-    headers: {
-      apikey: SUPABASE_ANON_KEY,
-      Authorization: `Bearer ${token}`,
-    },
-  });
-  if (!res.ok) {
-    const err = await res.text();
-    throw new Error(err);
-  }
-  return res.json();
+  const { data, error } = await supabase
+    .from('movies')
+    .select('*')
+    .eq('user_id', user.id);
+  if (error) throw error;
+  return data;
 }
-

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,101 @@
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+function getToken() {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('sb-access-token');
+}
+
+function setToken(token: string | null) {
+  if (typeof window === 'undefined') return;
+  if (token) localStorage.setItem('sb-access-token', token);
+  else localStorage.removeItem('sb-access-token');
+}
+
+async function authRequest(path: string, body: any) {
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: SUPABASE_ANON_KEY,
+    },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error?.message || 'Auth error');
+  if (data.session?.access_token) setToken(data.session.access_token);
+  if (data.access_token) setToken(data.access_token);
+  return data;
+}
+
+export async function signUp(email: string, password: string) {
+  return authRequest('signup', { email, password });
+}
+
+export async function signIn(email: string, password: string) {
+  return authRequest('token?grant_type=password', { email, password });
+}
+
+export async function signOut() {
+  setToken(null);
+}
+
+export async function getUser() {
+  const token = getToken();
+  if (!token) return null;
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/user`, {
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.user;
+}
+
+export async function insertMovie(movie: { title: string; story: string; animation: any; }) {
+  const token = getToken();
+  if (!token) throw new Error('Not authenticated');
+  const user = await getUser();
+  if (!user) throw new Error('Not authenticated');
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/movies`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+    },
+    body: JSON.stringify({
+      user_id: user.id,
+      title: movie.title,
+      story: movie.story,
+      animation: movie.animation,
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(err);
+  }
+  return res.json();
+}
+
+export async function getMoviesByUser() {
+  const token = getToken();
+  if (!token) throw new Error('Not authenticated');
+  const user = await getUser();
+  if (!user) throw new Error('Not authenticated');
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/movies?user_id=eq.${user.id}&select=*`, {
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(err);
+  }
+  return res.json();
+}
+

--- a/package.json
+++ b/package.json
@@ -8,24 +8,26 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@phosphor-icons/react": "^2.1.6",
+    "framer-motion": "11.2.10",
     "next": "14.2.5",
+    "openai": "^4.57.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "framer-motion": "11.2.10",
-    "openai": "^4.57.0",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.23.0",
-    "@phosphor-icons/react": "^2.1.6"
+    "@supabase/supabase-js": "^2.39.1",
+    "@supabase/ssr": "^0.10.0"
   },
   "devDependencies": {
     "@types/node": "20.12.12",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
+    "autoprefixer": "^10.4.16",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.5",
-    "typescript": "5.5.4",
-    "tailwindcss": "^3.4.4",
     "postcss": "^8.4.31",
-    "autoprefixer": "^10.4.16"
+    "tailwindcss": "^3.4.4",
+    "typescript": "5.5.4"
   }
 }


### PR DESCRIPTION
## Summary
- Integrate Supabase using custom client
- Add user registration and login pages
- Enable saving and listing movies for authenticated users
- Provide SQL schema and policies for movies table

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5abde13b4832692ce83b416a3295b