### PR TITLE
Add AI-generated movie titles and descriptions

### DIFF
--- a/Supabase.sql
+++ b/Supabase.sql
@@ -2,6 +2,7 @@ create table if not exists public.movies (
   id uuid primary key default gen_random_uuid(),
   user_id uuid references auth.users(id),
   title text,
+  description text,
   story text,
   animation jsonb,
   created_at timestamptz default now()
@@ -20,3 +21,9 @@ create policy "Users can update their own movies" on public.movies
 
 create policy "Users can delete their own movies" on public.movies
   for delete using (auth.uid() = user_id);
+
+-- Migration: ensure description column exists and backfill
+alter table public.movies
+  add column if not exists description text;
+
+update public.movies set description = coalesce(description, '');

--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -23,7 +23,10 @@ export default function MoviesPage() {
       <ul className="mb-8 space-y-2">
         {movies.map(m => (
           <li key={m.id} className="flex justify-between items-center border p-2 rounded">
-            <span>{m.title || m.story.slice(0,30)}</span>
+            <div>
+              <div className="font-medium">{m.title || m.story.slice(0,30)}</div>
+              {m.description && <div className="text-xs text-gray-500">{m.description}</div>}
+            </div>
             <button onClick={() => setSelected(m)} className="text-blue-600 underline">Play</button>
           </li>
         ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -132,7 +132,8 @@ export default function Page() {
                   return;
                 }
                 const saved = await insertMovie({
-                  title: storyText.substring(0, 30),
+                  title: animation?.title || storyText.substring(0, 30),
+                  description: animation?.description || '',
                   story: storyText,
                   animation,
                 });

--- a/components/AnimationTypes.ts
+++ b/components/AnimationTypes.ts
@@ -53,6 +53,8 @@ export type Scene = {
 
 export type Animation = {
   title: string;
+  /** Short summary describing the movie */
+  description: string;
   fps: number; // for time normalization if needed
   scenes: Scene[];
 };

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -134,15 +134,18 @@ function SceneThumbnail({ scene }: { scene: Scene }) {
 export function MovieCard({
   movie,
 }: {
-  movie: { title?: string; story: string; animation: Animation };
+  movie: { title?: string; description?: string; story: string; animation: Animation };
 }) {
   const firstScene = movie.animation?.scenes?.[0];
   return (
-    <div className="space-y-2">
+    <div className="space-y-1">
       {firstScene ? <SceneThumbnail scene={firstScene} /> : null}
       <div className="text-sm font-medium truncate">
         {movie.title || movie.story.slice(0, 30)}
       </div>
+      {movie.description && (
+        <div className="text-xs text-gray-500 truncate">{movie.description}</div>
+      )}
     </div>
   );
 }

--- a/lib/prompt/buildStoryboardPrompt.ts
+++ b/lib/prompt/buildStoryboardPrompt.ts
@@ -18,6 +18,9 @@ export function buildStoryboardPrompt(config: PromptConfig) {
   const systemPrompt = `You support the following visual effects that run at scene start and may be applied to scenes or actors via an "effects" array:\n${effectsList}\nUse only these names. Add effects when they enhance the story; omit otherwise.`;
 
   const storyboardPrompt = `You convert a short story into an animated storyboard JSON.
+The JSON must include:
+ - "title": a concise movie title describing the whole story (no scene numbers or names).
+ - "description": a summary of the entire movie of at most 50 words.
 You may use any emoji for actors or backgrounds. These examples show common emoji with suggested default scales:
 Actors:\n${actorsExamples}\nBackgrounds:\n${backgroundsExamples}\nConstraints:
  - Max ${config.maxScenes} scenes, max ${config.maxActorsPerScene} actors per scene, total duration <= ${config.maxTotalDurationMs} ms.

--- a/lib/sampleAnimation.ts
+++ b/lib/sampleAnimation.ts
@@ -2,6 +2,7 @@ import type { Animation } from '../components/AnimationTypes';
 
 export const SAMPLE_ANIMATION: Animation = {
   title: 'The Lost Balloon',
+  description: 'A curious cat chases a drifting red balloon through the city skyline.',
   fps: 30,
   scenes: [
     {

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -51,6 +51,12 @@ export const sceneSchema = z.object({
 
 export const animationSchema = z.object({
   title: z.string(),
+  description: z
+    .string()
+    .refine(
+      (s) => s.trim().split(/\s+/).filter(Boolean).length <= 50,
+      { message: 'Must be 50 words or fewer' }
+    ),
   fps: z.number().positive(),
   scenes: z.array(sceneSchema).min(1)
 });

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -26,7 +26,7 @@ export async function getUser() {
   return data.user;
 }
 
-export async function insertMovie(movie: { title: string; story: string; animation: any; }) {
+export async function insertMovie(movie: { title: string; description: string; story: string; animation: any; }) {
   const user = await getUser();
   if (!user) throw new Error('Not authenticated');
   const { data, error } = await supabase
@@ -34,6 +34,7 @@ export async function insertMovie(movie: { title: string; story: string; animati
     .insert({
       user_id: user.id,
       title: movie.title,
+      description: movie.description,
       story: movie.story,
       animation: movie.animation,
     })


### PR DESCRIPTION
## Summary
- generate concise movie title and description from storyboards
- save description and title to Supabase movies table
- display descriptions in movie lists

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)
- `npx tsc -p tsconfig.json --noEmit` (fails: Cannot find module 'next/server' or its corresponding type declarations and more)


------
https://chatgpt.com/codex/tasks/task_e_68b5fd4ea17c8326acd43dddba434b24