### PR TITLE
feat: add movie editor

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import MovieEditor from '../../components/MovieEditor';
+
+export default function EditorPage() {
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4">Movie Editor</h1>
+      <MovieEditor />
+    </div>
+  );
+}
+

--- a/components/AnimationTypes.ts
+++ b/components/AnimationTypes.ts
@@ -39,7 +39,19 @@ export type CompositeActor = {
   effects?: Effect[];
 };
 
-export type Actor = EmojiActor | CompositeActor;
+export type TextActor = {
+  id: string;
+  type: 'text';
+  text: string;
+  start?: { x: number; y: number; scale: number };
+  tracks: Keyframe[];
+  color?: string;
+  fontSize?: number;
+  z?: number;
+  effects?: Effect[];
+};
+
+export type Actor = EmojiActor | CompositeActor | TextActor;
 
 export type Scene = {
   id: string;

--- a/components/EmojiPlayer.tsx
+++ b/components/EmojiPlayer.tsx
@@ -418,6 +418,23 @@ function ActorView({
     );
     return wrapWithEffects(node, actor.effects, 'span');
   }
+  if (actor.type === 'text') {
+    const size = actor.fontSize ?? Math.round(32 * (actor.start?.scale ?? 1));
+    const node = (
+      <span
+        style={{
+          position: 'absolute',
+          transform: `translate(${x}px, ${y}px) rotate(${rotate}deg) scale(${scale})`,
+          color: actor.color ?? 'white',
+          fontSize: size,
+          whiteSpace: 'pre'
+        }}
+      >
+        {actor.text}
+      </span>
+    );
+    return wrapWithEffects(node, actor.effects, 'span');
+  }
   if (actor.type === 'composite') {
     if (actor.parts.length === 0) return null;
 

--- a/components/EmojiPlayer.tsx
+++ b/components/EmojiPlayer.tsx
@@ -419,9 +419,11 @@ function ActorView({
         aria-label={actor.ariaLabel ?? actor.emoji}
         style={{
           position: 'absolute',
+          left: x,
+          top: y,
           fontSize: size,
-          transformOrigin: 'center center',
-          transform: `translate(${x}px, ${y}px) rotate(${rotate}deg) scale(${scale})`
+          transformOrigin: 'top left',
+          transform: `rotate(${rotate}deg) scale(${scale})`
         }}
       >
         <span style={{ display: 'inline-block', transform: actor.flipX ? 'scaleX(-1)' : undefined }}>
@@ -437,7 +439,10 @@ function ActorView({
       <span
         style={{
           position: 'absolute',
-          transform: `translate(${x}px, ${y}px) rotate(${rotate}deg) scale(${scale})`,
+          left: x,
+          top: y,
+          transformOrigin: 'top left',
+          transform: `rotate(${rotate}deg) scale(${scale})`,
           color: actor.color ?? 'white',
           fontSize: size,
           whiteSpace: 'pre'
@@ -482,11 +487,13 @@ function ActorView({
         aria-label={actor.ariaLabel ?? 'composite'}
         style={{
           position: 'absolute',
+          left: x,
+          top: y,
           width,
           height,
           display: 'inline-block',
-          transformOrigin: 'center center',
-          transform: `translate(${x}px, ${y}px) rotate(${rotate}deg) scale(${scale})`
+          transformOrigin: 'top left',
+          transform: `rotate(${rotate}deg) scale(${scale})`
         }}
       >
         <span
@@ -512,7 +519,7 @@ function ActorView({
                   left: offsetX,
                   top: offsetY,
                   fontSize: partSize,
-                  transformOrigin: 'center center'
+                  transformOrigin: 'top left'
                 }}
               >
                 <span style={{ display: 'inline-block', transform: p.flipX ? 'scaleX(-1)' : undefined }}>

--- a/components/EmojiPlayer.tsx
+++ b/components/EmojiPlayer.tsx
@@ -387,11 +387,24 @@ function ActorView({
   duration: number;
   progress: number;
 }) {
-  const times = actor.tracks.map((k) => k.t / Math.max(1, duration));
-  const xVals = actor.tracks.map((k) => k.x * w);
-  const yVals = actor.tracks.map((k) => k.y * h);
-  const rotateVals = actor.tracks.map((k) => k.rotate ?? 0);
-  const scaleVals = actor.tracks.map((k) => k.scale ?? actor.start?.scale ?? 1);
+  const frames = [
+    actor.start && {
+      t: 0,
+      x: actor.start.x,
+      y: actor.start.y,
+      rotate: 0,
+      scale: actor.start.scale
+    },
+    ...actor.tracks
+  ]
+    .filter(Boolean)
+    .sort((a, b) => a.t - b.t);
+
+  const times = frames.map((k) => k.t / Math.max(1, duration));
+  const xVals = frames.map((k) => k.x * w);
+  const yVals = frames.map((k) => k.y * h);
+  const rotateVals = frames.map((k) => k.rotate ?? 0);
+  const scaleVals = frames.map((k) => k.scale ?? actor.start?.scale ?? 1);
 
   const x = sampleAt(times, xVals, progress);
   const y = sampleAt(times, yVals, progress);

--- a/components/MovieEditor.tsx
+++ b/components/MovieEditor.tsx
@@ -1,0 +1,413 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Animation, Scene, Actor, EmojiActor, TextActor, Keyframe } from './AnimationTypes';
+import { EmojiPlayer } from './EmojiPlayer';
+
+function uuid() {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
+}
+
+type SceneEditorProps = {
+  scene: Scene;
+  onChange: (s: Scene) => void;
+  onRemove: () => void;
+};
+
+export default function MovieEditor() {
+  const [animation, setAnimation] = useState<Animation>({
+    title: 'Untitled Movie',
+    description: '',
+    fps: 30,
+    scenes: []
+  });
+
+  const updateScene = (idx: number, scene: Scene) => {
+    setAnimation((a) => {
+      const scenes = [...a.scenes];
+      scenes[idx] = scene;
+      return { ...a, scenes };
+    });
+  };
+
+  const addScene = () => {
+    const scene: Scene = {
+      id: uuid(),
+      duration_ms: 1000,
+      backgroundActors: [],
+      actors: []
+    };
+    setAnimation((a) => ({ ...a, scenes: [...a.scenes, scene] }));
+  };
+
+  const removeScene = (idx: number) => {
+    setAnimation((a) => {
+      const scenes = [...a.scenes];
+      scenes.splice(idx, 1);
+      return { ...a, scenes };
+    });
+  };
+
+  return (
+    <div className="flex flex-col md:flex-row gap-6">
+      <div className="md:w-1/2 space-y-4">
+        <div>
+          <label className="block text-sm font-medium">Title</label>
+          <input
+            className="border rounded px-2 py-1 w-full"
+            value={animation.title}
+            onChange={(e) => setAnimation((a) => ({ ...a, title: e.target.value }))}
+          />
+        </div>
+        {animation.scenes.map((s, i) => (
+          <SceneEditor
+            key={s.id}
+            scene={s}
+            onChange={(sc) => updateScene(i, sc)}
+            onRemove={() => removeScene(i)}
+          />
+        ))}
+        <button
+          className="bg-blue-600 text-white px-3 py-1 rounded"
+          onClick={addScene}
+        >
+          Add Scene
+        </button>
+      </div>
+      <div className="md:w-1/2">
+        {animation.scenes.length > 0 ? (
+          <EmojiPlayer animation={animation} width={600} height={400} />
+        ) : (
+          <div className="w-full h-64 border-2 border-dashed flex items-center justify-center text-gray-400">
+            No scenes yet
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SceneEditor({ scene, onChange, onRemove }: SceneEditorProps) {
+  const update = (fields: Partial<Scene>) => onChange({ ...scene, ...fields });
+
+  const updateActor = (idx: number, actor: Actor) => {
+    const actors = [...scene.actors];
+    actors[idx] = actor;
+    update({ actors });
+  };
+
+  const addActor = () => {
+    const actor: EmojiActor = {
+      id: uuid(),
+      type: 'emoji',
+      emoji: '😀',
+      start: { x: 0.5, y: 0.5, scale: 1 },
+      tracks: [{ t: 0, x: 0.5, y: 0.5 }]
+    };
+    update({ actors: [...scene.actors, actor] });
+  };
+
+  const addTextActor = () => {
+    const actor: TextActor = {
+      id: uuid(),
+      type: 'text',
+      text: 'Text',
+      start: { x: 0.5, y: 0.5, scale: 1 },
+      tracks: [{ t: 0, x: 0.5, y: 0.5 }]
+    };
+    update({ actors: [...scene.actors, actor] });
+  };
+
+  const removeActor = (idx: number) => {
+    const actors = [...scene.actors];
+    actors.splice(idx, 1);
+    update({ actors });
+  };
+
+  const updateBackground = (idx: number, actor: EmojiActor) => {
+    const backgroundActors = [...scene.backgroundActors];
+    backgroundActors[idx] = actor;
+    update({ backgroundActors });
+  };
+
+  const addBackground = () => {
+    const actor: EmojiActor = {
+      id: uuid(),
+      type: 'emoji',
+      emoji: '🌄',
+      start: { x: 0.5, y: 0.5, scale: 1 },
+      tracks: [{ t: 0, x: 0.5, y: 0.5 }]
+    };
+    update({ backgroundActors: [...scene.backgroundActors, actor] });
+  };
+
+  const removeBackground = (idx: number) => {
+    const backgroundActors = [...scene.backgroundActors];
+    backgroundActors.splice(idx, 1);
+    update({ backgroundActors });
+  };
+
+  return (
+    <div className="border rounded p-3 space-y-3">
+      <div className="flex justify-between items-center">
+        <h3 className="font-semibold">Scene</h3>
+        <button className="text-red-600" onClick={onRemove}>
+          Remove
+        </button>
+      </div>
+      <div>
+        <label className="block text-sm">Duration (ms)</label>
+        <input
+          type="number"
+          className="border rounded px-2 py-1 w-full"
+          value={scene.duration_ms}
+          onChange={(e) => update({ duration_ms: parseInt(e.target.value) || 0 })}
+        />
+      </div>
+      <div>
+        <label className="block text-sm">Caption</label>
+        <input
+          className="border rounded px-2 py-1 w-full"
+          value={scene.caption ?? ''}
+          onChange={(e) => update({ caption: e.target.value })}
+        />
+      </div>
+
+      <div>
+        <h4 className="font-medium">Background Actors</h4>
+        {scene.backgroundActors.map((a, i) => (
+          <ActorEditor
+            key={a.id}
+            actor={a}
+            onChange={(ac) => updateBackground(i, ac as EmojiActor)}
+            onRemove={() => removeBackground(i)}
+            allowTypeChange={false}
+          />
+        ))}
+        <button className="mt-2 text-sm text-blue-600" onClick={addBackground}>
+          Add Background Actor
+        </button>
+      </div>
+
+      <div>
+        <h4 className="font-medium">Actors</h4>
+        {scene.actors.map((a, i) => (
+          <ActorEditor
+            key={a.id}
+            actor={a}
+            onChange={(ac) => updateActor(i, ac)}
+            onRemove={() => removeActor(i)}
+          />
+        ))}
+        <div className="flex gap-2 mt-2">
+          <button className="text-sm text-blue-600" onClick={addActor}>
+            Add Emoji Actor
+          </button>
+          <button className="text-sm text-blue-600" onClick={addTextActor}>
+            Add Text Actor
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type ActorEditorProps = {
+  actor: Actor;
+  onChange: (a: Actor) => void;
+  onRemove: () => void;
+  allowTypeChange?: boolean;
+};
+
+function ActorEditor({ actor, onChange, onRemove, allowTypeChange = true }: ActorEditorProps) {
+  const update = (fields: any) => onChange({ ...actor, ...fields });
+
+  const updateStart = (field: keyof NonNullable<Actor['start']>, value: number) => {
+    const start = { x: 0, y: 0, scale: 1, ...(actor as any).start };
+    (start as any)[field] = value;
+    update({ start });
+  };
+
+  const updateTrack = (idx: number, field: keyof Keyframe, value: number) => {
+    const tracks = [...actor.tracks];
+    const kf = { ...tracks[idx] } as any;
+    kf[field] = value;
+    tracks[idx] = kf;
+    update({ tracks });
+  };
+
+  const addKeyframe = () => {
+    const tracks = [...actor.tracks, { t: 0, x: 0.5, y: 0.5 }];
+    update({ tracks });
+  };
+
+  const removeKeyframe = (idx: number) => {
+    const tracks = [...actor.tracks];
+    tracks.splice(idx, 1);
+    update({ tracks });
+  };
+
+  const handleTypeChange = (t: string) => {
+    if (t === actor.type) return;
+    if (t === 'emoji') {
+      const a: EmojiActor = {
+        id: actor.id,
+        type: 'emoji',
+        emoji: '😀',
+        start: { x: 0.5, y: 0.5, scale: 1 },
+        tracks: [{ t: 0, x: 0.5, y: 0.5 }]
+      };
+      onChange(a);
+    } else if (t === 'text') {
+      const a: TextActor = {
+        id: actor.id,
+        type: 'text',
+        text: 'Text',
+        start: { x: 0.5, y: 0.5, scale: 1 },
+        tracks: [{ t: 0, x: 0.5, y: 0.5 }]
+      };
+      onChange(a);
+    }
+  };
+
+  return (
+    <div className="border rounded p-2 mt-2 space-y-2">
+      <div className="flex justify-between items-center">
+        <div className="text-sm font-medium">Actor</div>
+        <button className="text-red-600 text-xs" onClick={onRemove}>
+          Remove
+        </button>
+      </div>
+      {allowTypeChange && (
+        <div>
+          <label className="block text-xs">Type</label>
+          <select
+            className="border rounded px-1 py-0.5 text-sm"
+            value={actor.type}
+            onChange={(e) => handleTypeChange(e.target.value)}
+          >
+            <option value="emoji">Emoji</option>
+            <option value="text">Text</option>
+          </select>
+        </div>
+      )}
+
+      {actor.type === 'emoji' && (
+        <div>
+          <label className="block text-xs">Emoji</label>
+          <input
+            className="border rounded px-1 py-0.5 text-sm"
+            value={(actor as EmojiActor).emoji}
+            onChange={(e) => update({ emoji: e.target.value })}
+          />
+        </div>
+      )}
+
+      {actor.type === 'text' && (
+        <>
+          <div>
+            <label className="block text-xs">Text</label>
+            <input
+              className="border rounded px-1 py-0.5 text-sm w-full"
+              value={(actor as TextActor).text}
+              onChange={(e) => update({ text: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="block text-xs">Color</label>
+            <input
+              className="border rounded px-1 py-0.5 text-sm"
+              value={(actor as TextActor).color ?? ''}
+              onChange={(e) => update({ color: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="block text-xs">Font Size</label>
+            <input
+              type="number"
+              className="border rounded px-1 py-0.5 text-sm"
+              value={(actor as TextActor).fontSize ?? ''}
+              onChange={(e) => update({ fontSize: e.target.value ? Number(e.target.value) : undefined })}
+            />
+          </div>
+        </>
+      )}
+
+      <div className="grid grid-cols-3 gap-2">
+        <div>
+          <label className="block text-xs">Start X</label>
+          <input
+            type="number"
+            className="border rounded px-1 py-0.5 text-sm w-full"
+            value={(actor.start?.x ?? 0).toString()}
+            onChange={(e) => updateStart('x', Number(e.target.value))}
+          />
+        </div>
+        <div>
+          <label className="block text-xs">Start Y</label>
+          <input
+            type="number"
+            className="border rounded px-1 py-0.5 text-sm w-full"
+            value={(actor.start?.y ?? 0).toString()}
+            onChange={(e) => updateStart('y', Number(e.target.value))}
+          />
+        </div>
+        <div>
+          <label className="block text-xs">Scale</label>
+          <input
+            type="number"
+            className="border rounded px-1 py-0.5 text-sm w-full"
+            value={(actor.start?.scale ?? 1).toString()}
+            onChange={(e) => updateStart('scale', Number(e.target.value))}
+          />
+        </div>
+      </div>
+
+      <div>
+        <div className="flex justify-between items-center">
+          <span className="text-xs font-medium">Keyframes</span>
+          <button className="text-xs text-blue-600" onClick={addKeyframe}>
+            Add
+          </button>
+        </div>
+        {actor.tracks.map((k, i) => (
+          <div key={i} className="grid grid-cols-5 gap-1 mt-1 text-xs items-center">
+            <input
+              type="number"
+              className="border rounded px-1 py-0.5"
+              value={k.t}
+              onChange={(e) => updateTrack(i, 't', Number(e.target.value))}
+            />
+            <input
+              type="number"
+              className="border rounded px-1 py-0.5"
+              value={k.x}
+              onChange={(e) => updateTrack(i, 'x', Number(e.target.value))}
+            />
+            <input
+              type="number"
+              className="border rounded px-1 py-0.5"
+              value={k.y}
+              onChange={(e) => updateTrack(i, 'y', Number(e.target.value))}
+            />
+            <input
+              type="number"
+              className="border rounded px-1 py-0.5"
+              value={k.scale ?? ''}
+              onChange={(e) => updateTrack(i, 'scale', Number(e.target.value))}
+            />
+            <button
+              className="text-red-600"
+              onClick={() => removeKeyframe(i)}
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/components/MovieEditor.tsx
+++ b/components/MovieEditor.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { Animation, Scene, Actor, EmojiActor, TextActor, Keyframe } from './AnimationTypes';
 import { EmojiPlayer } from './EmojiPlayer';
+import SceneCanvas from './SceneCanvas';
 
 function uuid() {
   return typeof crypto !== 'undefined' && 'randomUUID' in crypto
@@ -12,6 +13,7 @@ function uuid() {
 
 type SceneEditorProps = {
   scene: Scene;
+  fps: number;
   onChange: (s: Scene) => void;
   onRemove: () => void;
 };
@@ -65,6 +67,7 @@ export default function MovieEditor() {
           <SceneEditor
             key={s.id}
             scene={s}
+            fps={animation.fps}
             onChange={(sc) => updateScene(i, sc)}
             onRemove={() => removeScene(i)}
           />
@@ -89,7 +92,7 @@ export default function MovieEditor() {
   );
 }
 
-function SceneEditor({ scene, onChange, onRemove }: SceneEditorProps) {
+function SceneEditor({ scene, fps, onChange, onRemove }: SceneEditorProps) {
   const update = (fields: Partial<Scene>) => onChange({ ...scene, ...fields });
 
   const updateActor = (idx: number, actor: Actor) => {
@@ -174,6 +177,8 @@ function SceneEditor({ scene, onChange, onRemove }: SceneEditorProps) {
           onChange={(e) => update({ caption: e.target.value })}
         />
       </div>
+
+      <SceneCanvas scene={scene} fps={fps} onSceneChange={onChange} />
 
       <div>
         <h4 className="font-medium">Background Actors</h4>

--- a/components/MovieEditor.tsx
+++ b/components/MovieEditor.tsx
@@ -5,6 +5,9 @@ import { Animation, Scene, Actor, EmojiActor, TextActor, Keyframe } from './Anim
 import { EmojiPlayer } from './EmojiPlayer';
 import SceneCanvas from './SceneCanvas';
 
+const CANVAS_WIDTH = 600;
+const CANVAS_HEIGHT = 400;
+
 function uuid() {
   return typeof crypto !== 'undefined' && 'randomUUID' in crypto
     ? crypto.randomUUID()
@@ -81,7 +84,7 @@ export default function MovieEditor() {
       </div>
       <div className="md:w-1/2">
         {animation.scenes.length > 0 ? (
-          <EmojiPlayer animation={animation} width={600} height={400} />
+          <EmojiPlayer animation={animation} width={CANVAS_WIDTH} height={CANVAS_HEIGHT} />
         ) : (
           <div className="w-full h-64 border-2 border-dashed flex items-center justify-center text-gray-400">
             No scenes yet
@@ -178,7 +181,13 @@ function SceneEditor({ scene, fps, onChange, onRemove }: SceneEditorProps) {
         />
       </div>
 
-      <SceneCanvas scene={scene} fps={fps} onSceneChange={onChange} />
+      <SceneCanvas
+        scene={scene}
+        fps={fps}
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+        onSceneChange={onChange}
+      />
 
       <div>
         <h4 className="font-medium">Background Actors</h4>

--- a/components/SceneCanvas.tsx
+++ b/components/SceneCanvas.tsx
@@ -202,7 +202,8 @@ export default function SceneCanvas({ scene, fps, onSceneChange }: SceneCanvasPr
     const style: React.CSSProperties = {
       left: pose.x * 100 + '%',
       top: pose.y * 100 + '%',
-      transform: `translate(-50%, -50%) scale(${pose.scale})`
+      transform: `translate(-50%, -50%) scale(${pose.scale})`,
+      opacity: layer === 'actors' && isBg ? 0.5 : 1
     };
     const interactive = (layer === 'background' && isBg) || (layer === 'actors' && !isBg);
     return (
@@ -274,6 +275,7 @@ export default function SceneCanvas({ scene, fps, onSceneChange }: SceneCanvasPr
           {allActors.map((a, i) => {
             const points = buildPath(a);
             if (!points) return null;
+            const isBg = i < (scene.backgroundActors as Actor[]).length;
             return (
               <polyline
                 key={a.id}
@@ -281,6 +283,7 @@ export default function SceneCanvas({ scene, fps, onSceneChange }: SceneCanvasPr
                 fill="none"
                 stroke={colors[i % colors.length]}
                 strokeWidth={selected === a.id ? 2 : 1}
+                opacity={layer === 'actors' && isBg ? 0.5 : 1}
               />
             );
           })}

--- a/components/SceneCanvas.tsx
+++ b/components/SceneCanvas.tsx
@@ -6,10 +6,12 @@ import { Scene, Actor, Keyframe, TextActor } from './AnimationTypes';
 type SceneCanvasProps = {
   scene: Scene;
   fps: number;
+  width: number;
+  height: number;
   onSceneChange: (s: Scene) => void;
 };
 
-export default function SceneCanvas({ scene, fps, onSceneChange }: SceneCanvasProps) {
+export default function SceneCanvas({ scene, fps, width, height, onSceneChange }: SceneCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ w: 0, h: 0 });
   // track the current frame rather than raw milliseconds to avoid floating
@@ -268,7 +270,11 @@ export default function SceneCanvas({ scene, fps, onSceneChange }: SceneCanvasPr
           </button>
         </div>
       </div>
-      <div ref={containerRef} className="relative w-full h-64 border overflow-hidden">
+      <div
+        ref={containerRef}
+        className="relative w-full border overflow-hidden"
+        style={{ aspectRatio: `${width}/${height}` }}
+      >
         <svg
           className="absolute inset-0 w-full h-full pointer-events-none"
           viewBox={`0 0 ${size.w} ${size.h}`}

--- a/components/SceneCanvas.tsx
+++ b/components/SceneCanvas.tsx
@@ -82,7 +82,20 @@ export default function SceneCanvas({ scene, fps, onSceneChange }: SceneCanvasPr
   }
 
   function updateActor(id: string, kf: Keyframe) {
-    const actors = scene.actors.map((a) => (a.id === id ? upsert(a, kf) : a));
+    const actors = scene.actors.map((a) => {
+      if (a.id !== id) return a;
+      let updated = upsert(a, kf);
+      if (kf.t === 0) {
+        const start = {
+          ...(updated.start ?? { x: kf.x, y: kf.y, scale: kf.scale ?? 1 }),
+          x: kf.x,
+          y: kf.y,
+          scale: kf.scale ?? updated.start?.scale ?? 1
+        };
+        updated = { ...updated, start };
+      }
+      return updated;
+    });
     onSceneChange({ ...scene, actors });
   }
 

--- a/components/SceneCanvas.tsx
+++ b/components/SceneCanvas.tsx
@@ -204,7 +204,10 @@ export default function SceneCanvas({ scene, fps, onSceneChange }: SceneCanvasPr
         </button>
       </div>
       <div ref={containerRef} className="relative w-full h-64 border overflow-hidden">
-        <svg className="absolute inset-0 pointer-events-none">
+        <svg
+          className="absolute inset-0 w-full h-full pointer-events-none"
+          viewBox={`0 0 ${size.w} ${size.h}`}
+        >
           {scene.actors.map((a, i) => {
             const points = buildPath(a);
             if (!points) return null;

--- a/components/SceneCanvas.tsx
+++ b/components/SceneCanvas.tsx
@@ -124,10 +124,10 @@ export default function SceneCanvas({ scene, fps, onSceneChange }: SceneCanvasPr
     const rect = containerRef.current.getBoundingClientRect();
     const t = Math.round(currentFrame * frameMs);
     const pose = sample(findActor(actorId), t);
-    const centerX = rect.left + pose.x * rect.width;
-    const centerY = rect.top + pose.y * rect.height;
-    const offsetX = e.clientX - centerX;
-    const offsetY = e.clientY - centerY;
+    const left = rect.left + pose.x * rect.width;
+    const top = rect.top + pose.y * rect.height;
+    const offsetX = e.clientX - left;
+    const offsetY = e.clientY - top;
     dragRef.current = { id: actorId, offsetX, offsetY };
     window.addEventListener('pointermove', handleMove);
     window.addEventListener('pointerup', handleMoveEnd);
@@ -202,7 +202,8 @@ export default function SceneCanvas({ scene, fps, onSceneChange }: SceneCanvasPr
     const style: React.CSSProperties = {
       left: pose.x * 100 + '%',
       top: pose.y * 100 + '%',
-      transform: `translate(-50%, -50%) scale(${pose.scale})`,
+      transform: `scale(${pose.scale})`,
+      transformOrigin: 'top left',
       opacity: layer === 'actors' && isBg ? 0.5 : 1
     };
     const interactive = (layer === 'background' && isBg) || (layer === 'actors' && !isBg);

--- a/components/SceneCanvas.tsx
+++ b/components/SceneCanvas.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Scene, Actor, Keyframe, TextActor } from './AnimationTypes';
+
+type SceneCanvasProps = {
+  scene: Scene;
+  fps: number;
+  onSceneChange: (s: Scene) => void;
+};
+
+export default function SceneCanvas({ scene, fps, onSceneChange }: SceneCanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  const [current, setCurrent] = useState(0); // milliseconds
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const scaleRef = useRef<{
+    id: string;
+    startScale: number;
+    startX: number;
+    startY: number;
+    x: number;
+    y: number;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    if (containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      setSize({ w: rect.width, h: rect.height });
+    }
+  }, []);
+
+  const frameMs = 1000 / fps;
+
+  function lerp(a: number, b: number, t: number) {
+    return a + (b - a) * t;
+  }
+
+  function sample(actor: Actor, t: number) {
+    const tracks = [...actor.tracks].sort((a, b) => a.t - b.t);
+    if (tracks.length === 0) {
+      const s = actor.start || { x: 0, y: 0, scale: 1 };
+      return { x: s.x, y: s.y, scale: s.scale };
+    }
+    if (t <= tracks[0].t) {
+      const s = actor.start || tracks[0];
+      return { x: tracks[0].x, y: tracks[0].y, scale: tracks[0].scale ?? s.scale ?? 1 };
+    }
+    for (let i = 1; i < tracks.length; i++) {
+      const prev = tracks[i - 1];
+      const next = tracks[i];
+      if (t <= next.t) {
+        const tt = (t - prev.t) / (next.t - prev.t);
+        return {
+          x: lerp(prev.x, next.x, tt),
+          y: lerp(prev.y, next.y, tt),
+          scale: lerp(prev.scale ?? actor.start?.scale ?? 1, next.scale ?? actor.start?.scale ?? 1, tt)
+        };
+      }
+    }
+    const last = tracks[tracks.length - 1];
+    return { x: last.x, y: last.y, scale: last.scale ?? actor.start?.scale ?? 1 };
+  }
+
+  function upsert(actor: Actor, kf: Keyframe): Actor {
+    const tracks = [...actor.tracks];
+    const idx = tracks.findIndex((k) => k.t === kf.t);
+    if (idx >= 0) {
+      tracks[idx] = { ...tracks[idx], ...kf };
+    } else {
+      tracks.push(kf);
+    }
+    tracks.sort((a, b) => a.t - b.t);
+    return { ...actor, tracks };
+  }
+
+  function updateActor(id: string, kf: Keyframe) {
+    const actors = scene.actors.map((a) => (a.id === id ? upsert(a, kf) : a));
+    onSceneChange({ ...scene, actors });
+  }
+
+  const handleDragEnd = (actorId: string, info: any) => {
+    if (!containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const x = (info.point.x - rect.left) / rect.width;
+    const y = (info.point.y - rect.top) / rect.height;
+    const pose = sample(scene.actors.find((a) => a.id === actorId)!, current);
+    updateActor(actorId, { t: current, x, y, scale: pose.scale });
+  };
+
+  const handleScaleStart = (e: React.PointerEvent, actorId: string) => {
+    e.stopPropagation();
+    const pose = sample(scene.actors.find((a) => a.id === actorId)!, current);
+    scaleRef.current = {
+      id: actorId,
+      startScale: pose.scale,
+      startX: e.clientX,
+      startY: e.clientY,
+      x: pose.x,
+      y: pose.y
+    };
+    window.addEventListener('pointermove', handleScaleMove);
+    window.addEventListener('pointerup', handleScaleEnd);
+  };
+
+  const handleScaleMove = (e: PointerEvent) => {
+    const s = scaleRef.current;
+    if (!s) return;
+    const diff = e.clientY - s.startY;
+    const newScale = Math.max(0.1, s.startScale + diff / 100);
+    updateActor(s.id, { t: current, x: s.x, y: s.y, scale: newScale });
+  };
+
+  const handleScaleEnd = () => {
+    scaleRef.current = null;
+    window.removeEventListener('pointermove', handleScaleMove);
+    window.removeEventListener('pointerup', handleScaleEnd);
+  };
+
+  const selectedActor = scene.actors.find((a) => a.id === selected);
+  const pathPoints = selectedActor
+    ? selectedActor.tracks.map((k) => `${k.x * size.w},${k.y * size.h}`).join(' ')
+    : '';
+
+  return (
+    <div className="space-y-2">
+      <div ref={containerRef} className="relative w-full h-64 border overflow-hidden">
+        <svg className="absolute inset-0 pointer-events-none">
+          {selectedActor && <polyline points={pathPoints} fill="none" stroke="blue" />}
+        </svg>
+        {scene.actors.map((a) => {
+          const pose = sample(a, current);
+          const style: React.CSSProperties = {
+            left: pose.x * 100 + '%',
+            top: pose.y * 100 + '%',
+            transform: `translate(-50%, -50%) scale(${pose.scale})`
+          };
+          return (
+            <motion.div
+              key={a.id}
+              drag
+              dragMomentum={false}
+              dragConstraints={containerRef}
+              onDragStart={() => setSelected(a.id)}
+              onDragEnd={(e, info) => handleDragEnd(a.id, info)}
+              className={`absolute cursor-move select-none ${selected === a.id ? 'ring-2 ring-blue-500' : ''}`}
+              style={style}
+            >
+              {a.type === 'emoji' && <span>{(a as any).emoji}</span>}
+              {a.type === 'text' && (
+                <span style={{ color: (a as TextActor).color, fontSize: (a as TextActor).fontSize }}>
+                  {(a as TextActor).text}
+                </span>
+              )}
+              {selected === a.id && (
+                <div
+                  onPointerDown={(e) => handleScaleStart(e, a.id)}
+                  className="absolute w-3 h-3 bg-white border border-blue-500 bottom-0 right-0 cursor-se-resize"
+                />
+              )}
+            </motion.div>
+          );
+        })}
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={scene.duration_ms}
+        step={frameMs}
+        value={current}
+        onChange={(e) => setCurrent(Number(e.target.value))}
+        className="w-full"
+      />
+      <div className="text-xs text-center">
+        Frame {Math.round(current / frameMs)} / {Math.round(scene.duration_ms / frameMs)}
+      </div>
+    </div>
+  );
+}
+

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -37,7 +37,19 @@ export const compositeActorSchema = z.object({
   effects: z.array(effectSchema).optional()
 });
 
-export const actorSchema = z.union([emojiActorSchema, compositeActorSchema]);
+export const textActorSchema = z.object({
+  id: z.string(),
+  type: z.literal('text'),
+  text: z.string(),
+  start: z.object({ x: z.number(), y: z.number(), scale: z.number().positive() }),
+  tracks: z.array(keyframeSchema).min(1),
+  color: z.string().optional(),
+  fontSize: z.number().positive().optional(),
+  z: z.number().optional(),
+  effects: z.array(effectSchema).optional()
+});
+
+export const actorSchema = z.union([emojiActorSchema, compositeActorSchema, textActorSchema]);
 
 export const sceneSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## Summary
- add TextActor type and schema
- render text actors in EmojiPlayer
- introduce MovieEditor UI and /editor page for creating scenes, backgrounds, actors, and text

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68b61820ec1483269f2838fd1e3a8f9b