### PR TITLE
Add movie like functionality

### DIFF
--- a/Supabase.sql
+++ b/Supabase.sql
@@ -28,6 +28,25 @@ alter table public.movies
 
 update public.movies set description = coalesce(description, '');
 
+-- Likes table for tracking movie likes
+create table if not exists public.likes (
+  movie_id uuid references public.movies(id) on delete cascade,
+  user_id uuid references auth.users(id),
+  created_at timestamptz default now(),
+  primary key (movie_id, user_id)
+);
+
+alter table public.likes enable row level security;
+
+create policy "Public read access" on public.likes
+  for select using (true);
+
+create policy "Users can insert their own likes" on public.likes
+  for insert with check (auth.uid() = user_id);
+
+create policy "Users can delete their own likes" on public.likes
+  for delete using (auth.uid() = user_id);
+
 -- Channels table for user profiles
 create table if not exists public.channels (
   id uuid primary key default gen_random_uuid(),

--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Play, ArrowLeft, FilmSlate, Clock } from '@phosphor-icons/react';
-import { getMoviesByUser } from '../../lib/supabaseClient';
+import { Play, ArrowLeft, FilmSlate, Clock, Heart } from '@phosphor-icons/react';
+import { getMoviesByUser, likeMovie, getMovieLikes } from '../../lib/supabaseClient';
 import type { Animation } from '../../components/AnimationTypes';
 import { EmojiPlayer } from '../../components/EmojiPlayer';
 import { MovieCard } from '../../components/MovieCard';
@@ -12,6 +12,8 @@ export default function MoviesPage() {
   const [selected, setSelected] = useState<any | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [likes, setLikes] = useState(0);
+  const [liked, setLiked] = useState(false);
 
   useEffect(() => {
     getMoviesByUser()
@@ -19,6 +21,26 @@ export default function MoviesPage() {
       .catch(e => setError(e.message))
       .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    if (selected) {
+      getMovieLikes(selected.id).then(({ count, liked }) => {
+        setLikes(count);
+        setLiked(liked);
+      });
+    }
+  }, [selected]);
+
+  const toggleLike = async () => {
+    if (!selected) return;
+    try {
+      const { liked: newLiked } = await likeMovie(selected.id);
+      setLiked(newLiked);
+      setLikes((c) => c + (newLiked ? 1 : -1));
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   if (selected) {
     return (
@@ -43,6 +65,15 @@ export default function MoviesPage() {
                 {selected.description}
               </p>
             )}
+            <div className="mt-4 flex justify-center">
+              <button
+                onClick={toggleLike}
+                className={`flex items-center gap-2 px-4 py-2 rounded-lg border ${liked ? 'text-red-600 border-red-300 bg-red-50' : 'text-gray-600 border-gray-300'}`}
+              >
+                <Heart weight={liked ? 'fill' : 'regular'} />
+                <span>{likes}</span>
+              </button>
+            </div>
           </div>
 
           {/* Player */}


### PR DESCRIPTION
## Summary
- create likes table with policies
- add client helpers for toggling and fetching movie likes
- display like counts and toggle buttons on movie cards and detailed movie view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@phosphor-icons%2freact)*

------
https://chatgpt.com/codex/tasks/task_e_68b7085b13ac8326b5518d726b7445a1