### PR TITLE
Add Share button with analytics tracking and deep-link support

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable import/no-unresolved */
 import { FilmSlate, MagicWand, Play, Stop } from '@phosphor-icons/react';
 import { useState, useRef, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import type { Animation } from '../components/AnimationTypes';
 import { EmojiPlayer } from '../components/EmojiPlayer';
 import { MovieCard } from '../components/MovieCard';
@@ -19,6 +20,7 @@ export default function Page() {
   const [user, setUser] = useState<any>(null);
   const [movies, setMovies] = useState<any[]>([]);
   const playerRef = useRef<{ play: () => void; stop: () => void } | null>(null);
+  const router = useRouter();
 
   const canPlay = !!animation && animation.scenes.length > 0;
   const wordCount = storyText.trim().split(/\s+/).filter(word => word.length > 0).length;
@@ -193,10 +195,9 @@ export default function Page() {
                 <div
                   key={m.id}
                   onClick={(e) => {
-                    // Only set animation if the click wasn't on the channel link
                     const target = e.target as HTMLElement;
-                    if (!target.closest('a')) {
-                      setAnimation(m.animation as Animation);
+                    if (!target.closest('a,button')) {
+                      router.push(`/movies?movie=${m.id}`);
                     }
                   }}
                   className="cursor-pointer"

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Heart } from '@phosphor-icons/react';
+import { ShareButton } from './ShareButton';
 import type {
   Animation,
   Scene,
@@ -191,13 +192,16 @@ export function MovieCard({
             <span className="truncate">@{movie.channels.name}</span>
           </Link>
         )}
-        <button
-          onClick={toggleLike}
-          className={`flex items-center gap-1 text-xs ${liked ? 'text-red-600' : 'text-gray-500'}`}
-        >
-          <Heart weight={liked ? 'fill' : 'regular'} size={14} />
-          <span>{likes}</span>
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={toggleLike}
+            className={`flex items-center gap-1 text-xs ${liked ? 'text-red-600' : 'text-gray-500'}`}
+          >
+            <Heart weight={liked ? 'fill' : 'regular'} size={14} />
+            <span>{likes}</span>
+          </button>
+          <ShareButton movieId={movie.id} url={`/movies?movie=${movie.id}`} />
+        </div>
       </div>
     </div>
   );

--- a/components/ShareButton.tsx
+++ b/components/ShareButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { ShareNetwork } from '@phosphor-icons/react';
 import { trackShare } from '../lib/analytics';
 
@@ -18,7 +18,8 @@ export function ShareButton({ movieId, url }: ShareButtonProps) {
     return absolute;
   };
 
-  const handleShare = async () => {
+  const handleShare = async (e: React.MouseEvent) => {
+    e.stopPropagation();
     const shareUrl = getUrl();
     try {
       if (navigator.share) {

--- a/components/ShareButton.tsx
+++ b/components/ShareButton.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState } from 'react';
+import { ShareNetwork } from '@phosphor-icons/react';
+import { trackShare } from '../lib/analytics';
+
+interface ShareButtonProps {
+  movieId: string;
+  url?: string; // relative or absolute URL
+}
+
+export function ShareButton({ movieId, url }: ShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const getUrl = () => {
+    if (typeof window === 'undefined') return url ?? '';
+    const absolute = url ? new URL(url, window.location.origin).toString() : window.location.href;
+    return absolute;
+  };
+
+  const handleShare = async () => {
+    const shareUrl = getUrl();
+    try {
+      if (navigator.share) {
+        await navigator.share({ url: shareUrl });
+      } else if (navigator.clipboard) {
+        await navigator.clipboard.writeText(shareUrl);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
+      trackShare(movieId);
+    } catch (err) {
+      console.error('Share failed', err);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleShare}
+      className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700"
+      title="Share"
+    >
+      <ShareNetwork size={14} />
+      <span>{copied ? 'Copied!' : 'Share'}</span>
+    </button>
+  );
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,22 @@
+export function trackEvent(event: string, data?: Record<string, any>) {
+  try {
+    // Support generic analytics providers if available
+    if (typeof window !== 'undefined') {
+      const w = window as any;
+      if (w.analytics && typeof w.analytics.track === 'function') {
+        w.analytics.track(event, data);
+        return;
+      }
+      if (w.gtag) {
+        w.gtag('event', event, data);
+        return;
+      }
+    }
+  } catch (err) {
+    console.error('Analytics error', err);
+  }
+}
+
+export function trackShare(movieId: string) {
+  trackEvent('share_movie', { movieId });
+}

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -58,6 +58,16 @@ export async function getMoviesByUser() {
   return data;
 }
 
+export async function getMovieById(id: string) {
+  const { data, error } = await supabase
+    .from('movies')
+    .select('*')
+    .eq('id', id)
+    .single();
+  if (error) throw error;
+  return data;
+}
+
 export async function getAllMovies() {
   const { data, error } = await supabase
     .from('movies')


### PR DESCRIPTION
## Summary
- add ShareButton component using Web Share API with clipboard fallback
- track share events via new `trackShare` helper
- integrate ShareButton in MovieCard and movie view with deep-linking to `/movies?movie=<id>`

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in lockfile; run "yarn install" to update the lockfile)*
- `yarn install` *(fails: RequestError 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b712e84e7c832696f33f3198812591