### PR TITLE
Enable editing existing movies

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -1,12 +1,38 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import MovieEditor from '../../components/MovieEditor';
+import { getMovieById } from '../../lib/supabaseClient';
 
 export default function EditorPage() {
+  const searchParams = useSearchParams();
+  const id = searchParams.get('id');
+  const [movie, setMovie] = useState<any | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (id) {
+      setLoading(true);
+      getMovieById(id)
+        .then(setMovie)
+        .catch((e: any) => setError(e.message))
+        .finally(() => setLoading(false));
+    }
+  }, [id]);
+
   return (
     <div className="p-6 max-w-6xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">Movie Editor</h1>
-      <MovieEditor />
+      <h1 className="text-3xl font-bold mb-4">
+        {id ? 'Edit Movie' : 'Movie Editor'}
+      </h1>
+      {error && (
+        <div className="mb-4 p-3 bg-red-100 text-red-700 rounded">
+          {error}
+        </div>
+      )}
+      {loading ? <p>Loading...</p> : <MovieEditor movie={movie ?? undefined} />}
     </div>
   );
 }

--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, Suspense } from 'react';
 import Link from 'next/link';
-import { PlayIcon, FilmSlateIcon, ClockIcon } from '@phosphor-icons/react';
+import { PlayIcon, FilmSlateIcon, ClockIcon, PencilSimpleIcon } from '@phosphor-icons/react';
 import { getMoviesByUser } from '../../lib/supabaseClient';
 import { MovieCard } from '../../components/MovieCard';
 
@@ -114,16 +114,25 @@ function MoviesContent() {
                       {movie.story}
                     </p>
 
-                    {/* Play Button */}
-                    <Link
-                      href={`/movies/${movie.id}`}
-                      className="group/play w-full flex items-center justify-center gap-2 px-4 py-3 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 font-medium mt-auto"
-                    >
-                      <div className="flex items-center justify-center w-5 h-5 bg-white/20 rounded-full group-hover/play:bg-white/30 transition-colors">
-                        <PlayIcon weight="fill" size={12} className="text-white ml-0.5" />
-                      </div>
-                      Watch Movie
-                    </Link>
+                    {/* Action Buttons */}
+                    <div className="mt-auto flex gap-2">
+                      <Link
+                        href={`/movies/${movie.id}`}
+                        className="group/play flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 font-medium"
+                      >
+                        <div className="flex items-center justify-center w-5 h-5 bg-white/20 rounded-full group-hover/play:bg-white/30 transition-colors">
+                          <PlayIcon weight="fill" size={12} className="text-white ml-0.5" />
+                        </div>
+                        Watch
+                      </Link>
+                      <Link
+                        href={`/editor?id=${movie.id}`}
+                        className="group/edit flex items-center justify-center gap-2 px-4 py-3 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 font-medium"
+                      >
+                        <PencilSimpleIcon weight="bold" size={12} className="text-white" />
+                        Edit
+                      </Link>
+                    </div>
                   </div>
                 </div>
               ))}

--- a/components/MovieEditor.tsx
+++ b/components/MovieEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
     FilmSlateIcon,
     ClockIcon,
@@ -16,7 +16,11 @@ import { uuid } from '../lib/uuid';
 const CANVAS_WIDTH = 480;
 const CANVAS_HEIGHT = 270;
 
-export default function MovieEditor() {
+interface MovieEditorProps {
+    movie?: any;
+}
+
+export default function MovieEditor({ movie }: MovieEditorProps) {
     const [animation, setAnimation] = useState<Animation>({
         title: 'Untitled Movie',
         description: '',
@@ -24,6 +28,17 @@ export default function MovieEditor() {
         scenes: []
     });
     const [activeSceneIndex, setActiveSceneIndex] = useState(0);
+
+    useEffect(() => {
+        if (movie?.animation) {
+            setAnimation({
+                ...movie.animation,
+                title: movie.title ?? movie.animation.title ?? 'Untitled Movie',
+                description:
+                    movie.description ?? movie.animation.description ?? '',
+            });
+        }
+    }, [movie]);
 
     const updateScene = (idx: number, scene: Scene) => {
         setAnimation((a) => {


### PR DESCRIPTION
## Summary
- Allow editor to preload an existing movie via query parameter
- Add edit link on each movie card so users can open movies in the editor
- Update `MovieEditor` to accept an initial movie and populate state from it

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in lockfile)*
- `yarn install` *(fails: RequestError 403 when resolving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b7544c7bdc8326af9e1feef1d1a658