### PR TITLE
feat: enable composite actor editing

### DIFF
--- a/components/ActorEditor.tsx
+++ b/components/ActorEditor.tsx
@@ -174,34 +174,28 @@ export default function ActorEditor({ actor, onChange, onRemove, allowTypeChange
         const widthPx = (maxX - minX) * unitSize;
         const heightPx = (maxY - minY) * unitSize;
         const scale = Math.min(48 / widthPx, 48 / heightPx);
-        const offsetX = (48 - widthPx * scale) / 2;
-        const offsetY = (48 - heightPx * scale) / 2;
 
         return (
-            <div className="w-12 h-12 overflow-hidden relative">
+            <div className="w-12 h-12 flex items-center justify-center overflow-hidden">
                 <div
                     style={{
-                        width: widthPx,
-                        height: heightPx,
-                        position: 'absolute',
-                        left: offsetX,
-                        top: offsetY,
-                        transform: `scale(${scale})`,
-                        transformOrigin: 'top left'
+                        width: widthPx * scale,
+                        height: heightPx * scale,
+                        position: 'relative'
                     }}
                 >
                     {comp.parts.map((p) => {
                         const ps = p.start?.scale ?? 1;
-                        const partSize = unitSize * ps;
-                        const offsetX = ((p.start?.x ?? 0) - minX) * unitSize;
-                        const offsetY = ((p.start?.y ?? 0) - minY) * unitSize;
+                        const partSize = unitSize * ps * scale;
+                        const x = ((p.start?.x ?? 0) - minX) * unitSize * scale;
+                        const y = ((p.start?.y ?? 0) - minY) * unitSize * scale;
                         return (
                             <span
                                 key={p.id}
                                 style={{
                                     position: 'absolute',
-                                    left: offsetX,
-                                    top: offsetY,
+                                    left: x,
+                                    top: y,
                                     fontSize: partSize
                                 }}
                             >

--- a/components/ActorEditor.tsx
+++ b/components/ActorEditor.tsx
@@ -174,6 +174,8 @@ export default function ActorEditor({ actor, onChange, onRemove, allowTypeChange
         const widthPx = (maxX - minX) * unitSize;
         const heightPx = (maxY - minY) * unitSize;
         const scale = Math.min(48 / widthPx, 48 / heightPx);
+        const offsetX = (48 - widthPx * scale) / 2;
+        const offsetY = (48 - heightPx * scale) / 2;
 
         return (
             <div className="w-12 h-12 overflow-hidden relative">
@@ -181,9 +183,11 @@ export default function ActorEditor({ actor, onChange, onRemove, allowTypeChange
                     style={{
                         width: widthPx,
                         height: heightPx,
+                        position: 'absolute',
+                        left: offsetX,
+                        top: offsetY,
                         transform: `scale(${scale})`,
-                        transformOrigin: 'top left',
-                        position: 'relative'
+                        transformOrigin: 'top left'
                     }}
                 >
                     {comp.parts.map((p) => {

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -268,21 +268,21 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
                         </div>
                         <div className="flex gap-2">
                             <button
-                                className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors shadow-sm"
+                                className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50"
                                 onClick={addActor}
                             >
                                 <SmileyWinkIcon size={16} />
                                 Add Emoji
                             </button>
                             <button
-                                className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors shadow-sm"
+                                className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50"
                                 onClick={addTextActor}
                             >
                                 <TextTIcon size={16} />
                                 Add Text
                             </button>
                             <button
-                                className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors shadow-sm"
+                                className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50"
                                 onClick={addCompositeActor}
                             >
                                 <UsersIcon size={16} />

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -15,7 +15,7 @@ import {
     CopyIcon,
     TrashIcon
 } from '@phosphor-icons/react';
-import { Scene, Actor, EmojiActor, TextActor } from './AnimationTypes';
+import { Scene, Actor, EmojiActor, TextActor, CompositeActor } from './AnimationTypes';
 import SceneCanvas from './SceneCanvas';
 import ActorEditor from './ActorEditor';
 import { uuid } from '../lib/uuid';
@@ -59,6 +59,25 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
             id: uuid(),
             type: 'text',
             text: 'Hello World',
+            start: { x: 0.5, y: 0.5, scale: 1 },
+            tracks: [{ t: 0, x: 0.5, y: 0.5, rotate: 0 }]
+        };
+        update({ actors: [...scene.actors, actor] });
+    };
+
+    const addCompositeActor = () => {
+        const actor: CompositeActor = {
+            id: uuid(),
+            type: 'composite',
+            parts: [
+                {
+                    id: uuid(),
+                    type: 'emoji',
+                    emoji: '😀',
+                    start: { x: 0, y: 0, scale: 1 },
+                    tracks: []
+                }
+            ],
             start: { x: 0.5, y: 0.5, scale: 1 },
             tracks: [{ t: 0, x: 0.5, y: 0.5, rotate: 0 }]
         };
@@ -261,6 +280,13 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
                             >
                                 <TextTIcon size={16} />
                                 Add Text
+                            </button>
+                            <button
+                                className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors shadow-sm"
+                                onClick={addCompositeActor}
+                            >
+                                <UsersIcon size={16} />
+                                Add Composite
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- support switching to composite actors with part management
- allow adding composite actors in scenes and rendering them on canvas

## Testing
- `yarn install` *(fails: RequestError 403)*
- `yarn lint` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e50c4c2c83268a0eed6880727bfe