### PR TITLE
Link movies to channels

### DIFF
--- a/app/mymovies/page.tsx
+++ b/app/mymovies/page.tsx
@@ -11,7 +11,7 @@ function MoviesContent() {
   const [movies, setMovies] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [releaseId, setReleaseId] = useState<string | null>(null);
+  const [releaseMovie, setReleaseMovie] = useState<any | null>(null);
 
   useEffect(() => {
     getMoviesByUser()
@@ -144,13 +144,13 @@ function MoviesContent() {
                               <PencilSimpleIcon weight="bold" size={12} />
                               Edit
                             </Link>
-                            <button
-                              onClick={() => setReleaseId(movie.id)}
-                              className="flex items-center justify-center gap-1 px-3 py-1.5 bg-green-600 text-white rounded"
-                            >
-                              <UploadSimpleIcon weight="bold" size={12} className="text-white" />
-                              Publish
-                            </button>
+            <button
+              onClick={() => setReleaseMovie(movie)}
+              className="flex items-center justify-center gap-1 px-3 py-1.5 bg-green-600 text-white rounded"
+            >
+              <UploadSimpleIcon weight="bold" size={12} className="text-white" />
+              Publish
+            </button>
                           </>
                         )}
                       </div>
@@ -176,17 +176,17 @@ function MoviesContent() {
         )}
       </div>
       <ReleaseModal
-        isOpen={releaseId !== null}
-        onClose={() => setReleaseId(null)}
+        isOpen={releaseMovie !== null}
+        onClose={() => setReleaseMovie(null)}
         onConfirm={async (date) => {
-          if (!releaseId) return;
+          if (!releaseMovie) return;
           try {
-            const updated = await publishMovie(releaseId, date.toISOString());
-            setMovies(m => m.map(x => x.id === releaseId ? updated : x));
+            const updated = await publishMovie(releaseMovie.id, releaseMovie.channel_id, date.toISOString());
+            setMovies(m => m.map(x => x.id === releaseMovie.id ? updated : x));
           } catch (e: any) {
             setError(e.message);
           } finally {
-            setReleaseId(null);
+            setReleaseMovie(null);
           }
         }}
       />


### PR DESCRIPTION
## Summary
- Add channel-based movie ownership and row-level security policies
- Require channel IDs for movie insert, publish, and retrieval logic
- Allow selecting a channel when saving and publishing movies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b857a380048326aefb29c9f1dbdb56