### PR TITLE
feat: add user profile page with channels

### DIFF
--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { getProfileById, getUserChannels, getMoviesByUser } from '../../../lib/supabaseClient';
+import { MovieCard } from '../../../components/MovieCard';
+import Image from 'next/image';
+
+export default function UserPage({ params }: { params: { userId: string } }) {
+  const { userId } = params;
+  const [profile, setProfile] = useState<any | null>(null);
+  const [channels, setChannels] = useState<any[]>([]);
+  const [movies, setMovies] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [p, ch, mv] = await Promise.all([
+          getProfileById(userId).catch(() => null),
+          getUserChannels(userId),
+          getMoviesByUser(userId).catch(() => []),
+        ]);
+        setProfile(p);
+        setChannels(ch || []);
+        setMovies(mv || []);
+      } catch (e: any) {
+        setError(e.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [userId]);
+
+  if (loading) {
+    return <div className="min-h-screen flex items-center justify-center">Loading...</div>;
+  }
+
+  if (error) {
+    return <div className="min-h-screen flex items-center justify-center text-red-600">{error}</div>;
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100">
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold">
+            {profile?.display_name || 'Unknown User'}
+          </h1>
+          {profile?.avatar_url ? (
+            <Image
+              src={profile.avatar_url}
+              alt="Avatar"
+              width={96}
+              height={96}
+              className="w-24 h-24 rounded-full mx-auto mt-4 object-cover"
+            />
+          ) : (
+            <p className="text-gray-500 mt-4">This user hasn&apos;t set up a profile yet.</p>
+          )}
+        </div>
+
+        <section className="mb-12">
+          <h2 className="text-2xl font-semibold mb-4">Channels</h2>
+          {channels.length === 0 ? (
+            <p className="text-gray-500">This user has no channels yet.</p>
+          ) : (
+            <ul className="space-y-4">
+              {channels.map((ch) => (
+                <li key={ch.id} className="p-4 bg-white border border-gray-200 rounded-lg">
+                  <Link
+                    href={`/channel/${encodeURIComponent(ch.name)}`}
+                    className="text-lg font-medium text-blue-600 hover:underline"
+                  >
+                    {ch.name}
+                  </Link>
+                  {ch.description && (
+                    <p className="text-sm text-gray-600">{ch.description}</p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mb-4">Movies</h2>
+          {movies.length === 0 ? (
+            <p className="text-gray-500">No movies yet.</p>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {movies.map((movie) => (
+                <div
+                  key={movie.id}
+                  className="bg-white rounded-xl shadow-sm border border-gray-200 p-4"
+                >
+                  <MovieCard movie={movie} />
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+

--- a/components/ClipComments.tsx
+++ b/components/ClipComments.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { getComments, postComment, deleteComment, getUser } from '../lib/supabaseClient';
 
 interface Comment {
@@ -50,7 +51,13 @@ export function ClipComments({ movieId, movieOwnerId }: { movieId: string; movie
         {comments.map((c) => (
           <li key={c.id} className="p-4 bg-white border border-gray-200 rounded-lg">
             <p className="text-gray-700 text-sm whitespace-pre-wrap">
-              <span className="font-medium">{c.username ?? 'Unknown'}:</span> {c.content}
+              <Link
+                href={`/users/${c.user_id}`}
+                className="font-medium hover:underline"
+              >
+                {c.username ?? 'Unknown'}
+              </Link>
+              : {c.content}
             </p>
             <div className="text-xs text-gray-500 mt-1">
               {new Date(c.created_at).toLocaleString()}

--- a/components/MovieDetail.tsx
+++ b/components/MovieDetail.tsx
@@ -1,18 +1,20 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { ArrowLeftIcon, HeartIcon } from '@phosphor-icons/react';
 import type { Animation } from './AnimationTypes';
 import { EmojiPlayer } from './EmojiPlayer';
 import { ClipComments } from './ClipComments';
 import { ShareButton } from './ShareButton';
-import { likeMovie, getMovieLikes } from '../lib/supabaseClient';
+import { likeMovie, getMovieLikes, getUserChannels } from '../lib/supabaseClient';
 
 export function MovieDetail({ movie }: { movie: any }) {
   const router = useRouter();
   const [likes, setLikes] = useState(0);
   const [liked, setLiked] = useState(false);
+  const [authorChannel, setAuthorChannel] = useState<string | null>(null);
 
   useEffect(() => {
     if (movie?.id) {
@@ -20,6 +22,11 @@ export function MovieDetail({ movie }: { movie: any }) {
         setLikes(count);
         setLiked(liked);
       });
+    }
+    if (movie?.user_id) {
+      getUserChannels(movie.user_id)
+        .then((chs) => setAuthorChannel(chs?.[0]?.name || null))
+        .catch(() => setAuthorChannel(null));
     }
   }, [movie]);
 
@@ -54,6 +61,15 @@ export function MovieDetail({ movie }: { movie: any }) {
               {movie.description}
             </p>
           )}
+          <div className="mt-2 text-sm text-gray-600">
+            By{' '}
+            <Link
+              href={`/users/${movie.user_id}`}
+              className="text-blue-600 hover:underline"
+            >
+              {authorChannel ? `@${authorChannel}` : 'Unknown'}
+            </Link>
+          </div>
           <div className="mt-4 flex justify-center gap-2">
             <button
               onClick={toggleLike}

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -40,6 +40,16 @@ export async function getProfile() {
   return data;
 }
 
+export async function getProfileById(userId: string) {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
 export async function updateProfile(params: { display_name?: string; avatar_url?: string; metadata?: any }) {
   const user = await getUser();
   if (!user) throw new Error('Not authenticated');
@@ -60,13 +70,17 @@ export async function updateProfile(params: { display_name?: string; avatar_url?
   return data;
 }
 
-export async function getUserChannels() {
-  const user = await getUser();
-  if (!user) throw new Error('Not authenticated');
+export async function getUserChannels(userId?: string) {
+  let targetId = userId;
+  if (!targetId) {
+    const user = await getUser();
+    if (!user) throw new Error('Not authenticated');
+    targetId = user.id;
+  }
   const { data, error } = await supabase
     .from('channels')
     .select('*')
-    .eq('user_id', user.id);
+    .eq('user_id', targetId);
   if (error) throw error;
   return data;
 }
@@ -90,13 +104,17 @@ export async function insertMovie(movie: { channel_id: string; title: string; de
   return data;
 }
 
-export async function getMoviesByUser() {
-  const user = await getUser();
-  if (!user) throw new Error('Not authenticated');
+export async function getMoviesByUser(userId?: string) {
+  let targetId = userId;
+  if (!targetId) {
+    const user = await getUser();
+    if (!user) throw new Error('Not authenticated');
+    targetId = user.id;
+  }
   const { data, error } = await supabase
     .from('movies')
     .select(`*, channels!inner(name, id, user_id)`)
-    .eq('channels.user_id', user.id)
+    .eq('channels.user_id', targetId)
     .order('created_at', { ascending: false });
   if (error) throw error;
   return data;


### PR DESCRIPTION
## Summary
- add dynamic user profile route with profile, channels and movies
- expose getProfileById, parameterized getUserChannels/getMoviesByUser
- link authors to new profile pages from movie detail and comments

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8618e08c883268241ea3d218daa66