### PR TITLE
feat: allow tailwind css from dedicated folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ out/
 dist/
 build/
 
+# Generated Tailwind CSS
+tailwind/output.css
+
 # TypeScript
 *.tsbuildinfo
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import Head from 'next/head';
-import './globals.css';
+import '../tailwind/output.css';
 import { Navbar } from '../components/Navbar';
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "emoji-movie-mvp-ai",
   "private": true,
   "scripts": {
+    "predev": "npm run generate:tailwind",
     "dev": "next dev",
+    "prebuild": "npm run generate:tailwind",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "seo-check": "node scripts/seo-checklist.js"
+    "seo-check": "node scripts/seo-checklist.js",
+    "generate:tailwind": "tailwindcss -i ./tailwind/main.css -o ./tailwind/output.css"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.6",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     './app/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
     './lib/**/*.{js,ts,jsx,tsx}',
+    './tailwind/**/*.css',
   ],
   theme: {
     extend: {},

--- a/tailwind/main.css
+++ b/tailwind/main.css
@@ -1,3 +1,4 @@
+/* Base Tailwind layers for custom styling */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- load Tailwind from a dedicated `tailwind` directory so custom CSS files can live there
- update Tailwind config to scan the new directory
- add base Tailwind stylesheet and script to generate compiled CSS
- import generated Tailwind output in the root layout
- generate Tailwind CSS automatically before `dev` and `build`

## Testing
- `npm run lint`
- `npm run generate:tailwind`
- `OPENAI_API_KEY=test NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=example npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8678e5b7083269ab4d7228642eaf4