### PR TITLE
Add movie generation flow with channel selection and auth guard

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { signIn } from '../../../lib/supabaseClient';
 
 export default function LoginPage() {
@@ -43,6 +44,12 @@ export default function LoginPage() {
         {error && <p className="text-red-600 text-sm">{error}</p>}
         <button type="submit" className="bg-blue-600 text-white py-2 rounded">Login</button>
       </form>
+      <p className="text-center text-sm mt-4">
+        Don&apos;t have an account?{' '}
+        <Link href="/auth/register" className="text-blue-600 hover:underline">
+          Register
+        </Link>
+      </p>
     </div>
   );
 }

--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -1,17 +1,29 @@
 'use client';
 
 import { Suspense, useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import MovieEditor from '../../components/MovieEditor';
-import { getMovieById } from '../../lib/supabaseClient';
+import { getMovieById, getUser } from '../../lib/supabaseClient';
 
 function EditorContent() {
   const searchParams = useSearchParams();
   const id = searchParams.get('id');
   const copy = searchParams.get('copy');
+  const router = useRouter();
   const [movie, setMovie] = useState<any | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [authChecked, setAuthChecked] = useState(false);
+
+  useEffect(() => {
+    getUser().then(u => {
+      if (!u) {
+        router.replace('/auth/login');
+      } else {
+        setAuthChecked(true);
+      }
+    });
+  }, [router]);
 
   useEffect(() => {
     const targetId = id || copy;
@@ -30,6 +42,10 @@ function EditorContent() {
         .finally(() => setLoading(false));
     }
   }, [id, copy]);
+
+  if (!authChecked) {
+    return <div className="p-6 max-w-6xl mx-auto">Checking authentication...</div>;
+  }
 
   return (
     <div className="p-6 max-w-6xl mx-auto">

--- a/components/MovieEditor.tsx
+++ b/components/MovieEditor.tsx
@@ -37,6 +37,7 @@ export default function MovieEditor({ movie }: MovieEditorProps) {
     const [error, setError] = useState<string | null>(null);
     const [movieId, setMovieId] = useState<string | undefined>(movie?.id);
     const [channelId, setChannelId] = useState<string | undefined>(movie?.channel_id);
+    const [channels, setChannels] = useState<any[]>([]);
     const [saving, setSaving] = useState(false);
     const [saveMessage, setSaveMessage] = useState<string | null>(null);
 
@@ -55,14 +56,16 @@ export default function MovieEditor({ movie }: MovieEditorProps) {
     }, [movie]);
 
     useEffect(() => {
-        if (!channelId) {
-            getUserChannels()
-                .then(ch => {
-                    if (ch && ch.length > 0) setChannelId(ch[0].id);
-                })
-                .catch(() => {});
-        }
-    }, [channelId]);
+        getUserChannels()
+            .then(ch => {
+                setChannels(ch);
+                if (!channelId && ch.length === 1) {
+                    setChannelId(ch[0].id);
+                }
+            })
+            .catch(() => {});
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const updateScene = (idx: number, scene: Scene) => {
         setAnimation((a) => {
@@ -185,6 +188,25 @@ export default function MovieEditor({ movie }: MovieEditorProps) {
                                     onChange={(e) => setAnimation((a) => ({ ...a, fps: Number(e.target.value) || 30 }))}
                                 />
                             </div>
+                            {channels.length > 1 && (
+                                <div className="flex items-center gap-2">
+                                    <label className="text-sm font-medium text-gray-700">Channel:</label>
+                                    <select
+                                        className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                        value={channelId || ''}
+                                        onChange={(e) => setChannelId(e.target.value)}
+                                    >
+                                        <option value="" disabled>
+                                            Select channel
+                                        </option>
+                                        {channels.map((ch) => (
+                                            <option key={ch.id} value={ch.id}>
+                                                {ch.name}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            )}
                             <button
                                 className="inline-flex items-center gap-2 px-3 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors disabled:opacity-50"
                                 onClick={saveMovie}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -14,6 +14,7 @@ import {
     MagnifyingGlass,
     CaretDown,
     List,
+    MagicWandIcon,
 } from '@phosphor-icons/react';
 
 export function Navbar() {
@@ -156,6 +157,13 @@ export function Navbar() {
                             <FilmSlateIcon size={18} weight="fill" />
                             <span>Movies</span>
                         </Link>
+                        <Link
+                            href={user ? '/editor' : '/auth/login'}
+                            className="flex items-center gap-2 bg-white text-brand-600 hover:bg-gray-100 transition-colors duration-200 px-4 py-2 rounded-md font-medium shadow-sm"
+                        >
+                            <MagicWandIcon size={18} weight="bold" />
+                            <span>Generate Movie</span>
+                        </Link>
 
                         {user ? (
                             <div className="relative" ref={dropdownRef}>
@@ -267,6 +275,14 @@ export function Navbar() {
                             >
                                 <FilmSlateIcon size={20} weight="fill" />
                                 Movies
+                            </Link>
+                            <Link
+                                href={user ? '/editor' : '/auth/login'}
+                                onClick={() => setIsMobileMenuOpen(false)}
+                                className="flex items-center gap-3 bg-white text-brand-600 hover:bg-gray-100 px-3 py-2 rounded-md font-medium transition-colors duration-200"
+                            >
+                                <MagicWandIcon size={20} weight="bold" />
+                                Generate Movie
                             </Link>
 
                             {user ? (


### PR DESCRIPTION
## Summary
- add Generate Movie button to navbar and mobile menu
- require login before accessing movie editor
- let editors pick a channel when multiple exist
- link register option from login page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b93f3a448483269f1c5796c101dd2f