### PR TITLE
feat: selectable emoji fonts in editor

### DIFF
--- a/app/api/og/[clipId]/route.tsx
+++ b/app/api/og/[clipId]/route.tsx
@@ -18,6 +18,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
   } catch {}
 
   const scene: Scene | undefined = clip?.animation?.scenes?.[0];
+  const emojiFont = clip?.animation?.emojiFont;
   const width = 1200;
   const height = Math.round((width * 9) / 16);
   const baseUnit = width / 12.5;
@@ -40,6 +41,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
           left,
           top,
           fontSize: size,
+          fontFamily: emojiFont,
           ...(a.flipX ? { transform: 'scaleX(-1)' } : {}),
         }}
       >
@@ -107,6 +109,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
                   left: offsetX,
                   top: offsetY,
                   fontSize: partSize,
+                  fontFamily: emojiFont,
                   ...(p.flipX ? { transform: 'scaleX(-1)' } : {}),
                 }}
               >

--- a/app/api/thumbnail/[clipId]/route.tsx
+++ b/app/api/thumbnail/[clipId]/route.tsx
@@ -18,6 +18,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
   } catch {}
 
   const scene: Scene | undefined = clip?.animation?.scenes?.[0];
+  const emojiFont = clip?.animation?.emojiFont;
   const width = 400;
   const height = Math.round((width * 9) / 16);
   const title = clip?.title || 'Emoji Clip';
@@ -39,6 +40,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
           left,
           top,
           fontSize: size,
+          fontFamily: emojiFont,
           ...(a.flipX ? { transform: 'scaleX(-1)' } : {}),
         }}
       >
@@ -106,6 +108,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
                   left: offsetX,
                   top: offsetY,
                   fontSize: partSize,
+                  fontFamily: emojiFont,
                   ...(p.flipX ? { transform: 'scaleX(-1)' } : {}),
                 }}
               >

--- a/components/ActorEditor.tsx
+++ b/components/ActorEditor.tsx
@@ -27,14 +27,17 @@ export type ActorEditorProps = {
     onChange: (a: Actor) => void;
     onRemove: () => void;
     allowTypeChange?: boolean;
+    emojiFont?: string;
 };
 
-export default function ActorEditor({ actor, onChange, onRemove, allowTypeChange = true }: ActorEditorProps) {
+export default function ActorEditor({ actor, onChange, onRemove, allowTypeChange = true, emojiFont }: ActorEditorProps) {
     const [isExpanded, setIsExpanded] = useState(false);
     const [showEmojiCatalogue, setShowEmojiCatalogue] = useState(false);
     const [partCatalogueIndex, setPartCatalogueIndex] = useState<number | null>(null);
     const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
     const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
+    const emojiStyle = emojiFont ? { fontFamily: emojiFont } : undefined;
 
     const update = (fields: any) => onChange({ ...actor, ...fields });
 
@@ -258,7 +261,8 @@ export default function ActorEditor({ actor, onChange, onRemove, allowTypeChange
                                     position: 'absolute',
                                     left: x,
                                     top: y,
-                                    fontSize: partSize
+                                    fontSize: partSize,
+                                    fontFamily: emojiFont
                                 }}
                             >
                                 <span
@@ -310,7 +314,7 @@ export default function ActorEditor({ actor, onChange, onRemove, allowTypeChange
                     >
                         <div className="flex items-center gap-2">
                             {getActorIcon()}
-                            <span className="text-lg">{getActorPreview()}</span>
+                            <span className="text-lg" style={emojiStyle}>{getActorPreview()}</span>
                         </div>
                         <div className="flex items-center gap-2 text-sm text-gray-500">
                             <span>{actor.type}</span>
@@ -706,6 +710,7 @@ export default function ActorEditor({ actor, onChange, onRemove, allowTypeChange
                         setShowEmojiCatalogue(false);
                         setPartCatalogueIndex(null);
                     }}
+                    emojiFont={emojiFont}
                 />
             )}
         </>

--- a/components/AnimationTypes.ts
+++ b/components/AnimationTypes.ts
@@ -69,4 +69,6 @@ export type Animation = {
   description: string;
   fps: number; // for time normalization if needed
   scenes: Scene[];
+  /** Optional font-family name for rendering emoji */
+  emojiFont?: string;
 };

--- a/components/EmojiCatalogue.tsx
+++ b/components/EmojiCatalogue.tsx
@@ -47,12 +47,13 @@ type EmojiCatalogueProps = {
     onSelectEmoji: (emoji: string) => void;
     onClose: () => void;
     isOpen: boolean;
+    emojiFont?: string;
 };
 
 const normalize = (s: string) => s.normalize('NFKD').toLowerCase();
 const toCategory = (idx: number) => GROUPS[idx] ?? 'Other';
 
-export default function EmojiCatalogue({ onSelectEmoji, onClose, isOpen }: EmojiCatalogueProps) {
+export default function EmojiCatalogue({ onSelectEmoji, onClose, isOpen, emojiFont }: EmojiCatalogueProps) {
     const [allEmojis, setAllEmojis] = useState<EmojiItem[] | null>(null);
     const [error, setError] = useState<string | null>(null);
 
@@ -212,6 +213,7 @@ export default function EmojiCatalogue({ onSelectEmoji, onClose, isOpen }: Emoji
                                     className="aspect-square flex items-center justify-center text-2xl hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-orange-300 focus:bg-blue-50"
                                     title={e.name}
                                     aria-label={e.name}
+                                    style={emojiFont ? { fontFamily: emojiFont } : undefined}
                                 >
                                     {e.emoji}
                                 </button>

--- a/components/EmojiPlayer.tsx
+++ b/components/EmojiPlayer.tsx
@@ -111,6 +111,7 @@ export const EmojiPlayer = forwardRef(function EmojiPlayer(
   const totalScenes = animation.scenes.length;
   const scene = animation.scenes[sceneIndex];
   const duration = Math.max(1, scene?.duration_ms ?? 1);
+  const emojiStyle = animation.emojiFont ? { fontFamily: animation.emojiFont } : undefined;
 
   function clearRaf() {
     if (rafRef.current != null) {
@@ -450,7 +451,8 @@ function ActorView({
           top: `${y}%`,
           fontSize: size,
           transformOrigin: 'center center',
-          transform: `translate(-50%, -50%) rotate(${rotate}deg) scale(${scale})`
+          transform: `translate(-50%, -50%) rotate(${rotate}deg) scale(${scale})`,
+          ...emojiStyle,
         }}
       >
         <span style={{ display: 'inline-block', transform: actor.flipX ? 'scaleX(-1)' : undefined }}>
@@ -546,7 +548,8 @@ function ActorView({
                   left: offsetX,
                   top: offsetY,
                   fontSize: partSize,
-                  transformOrigin: 'center center'
+                  transformOrigin: 'center center',
+                  ...emojiStyle,
                 }}
               >
                 <span style={{ display: 'inline-block', transform: p.flipX ? 'scaleX(-1)' : undefined }}>

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -11,7 +11,7 @@ import type {
 } from './AnimationTypes';
 import { likeMovie, getMovieLikes } from '../lib/supabaseClient';
 
-function SceneThumbnail({ scene }: { scene: Scene }) {
+function SceneThumbnail({ scene, emojiFont }: { scene: Scene; emojiFont?: string }) {
   const width = 160;
   const height = (width * 9) / 16; // match EmojiPlayer aspect ratio
 
@@ -33,6 +33,7 @@ function SceneThumbnail({ scene }: { scene: Scene }) {
           top: `${top}%`,
           fontSize: size,
           transform: 'translate(-50%, -50%)',
+          fontFamily: emojiFont,
         }}
       >
         <span
@@ -105,6 +106,7 @@ function SceneThumbnail({ scene }: { scene: Scene }) {
                   left: offsetX,
                   top: offsetY,
                   fontSize: partSize,
+                  fontFamily: emojiFont,
                 }}
               >
                 <span
@@ -174,7 +176,9 @@ export function MovieCard({
 
   return (
     <div className="space-y-2">
-      {firstScene ? <SceneThumbnail scene={firstScene} /> : null}
+      {firstScene ? (
+        <SceneThumbnail scene={firstScene} emojiFont={movie.animation?.emojiFont} />
+      ) : null}
       <div className="space-y-1">
         <div className="text-sm font-medium truncate">
           {movie.title || movie.story.slice(0, 30)}

--- a/components/MovieEditor.tsx
+++ b/components/MovieEditor.tsx
@@ -28,7 +28,8 @@ export default function MovieEditor({ movie }: MovieEditorProps) {
         title: 'Untitled Movie',
         description: '',
         fps: 30,
-        scenes: []
+        scenes: [],
+        emojiFont: undefined
     });
     const [activeSceneIndex, setActiveSceneIndex] = useState(0);
     const [showGenerator, setShowGenerator] = useState(false);
@@ -178,21 +179,41 @@ export default function MovieEditor({ movie }: MovieEditorProps) {
                             <h1 className="text-xl font-semibold text-gray-900">Movie Editor</h1>
                         </div>
                         <div className="flex items-center gap-4">
+                        <div className="flex items-center gap-2">
+                            <ClockIcon size={16} className="text-gray-500" />
+                            <label className="text-sm font-medium text-gray-700">FPS:</label>
+                            <input
+                                type="number"
+                                className="border border-gray-300 rounded-md px-2 py-1 w-16 text-sm focus:ring-2 focus:ring-orange-300 focus:border-transparent"
+                                value={animation.fps}
+                                onChange={(e) => setAnimation((a) => ({ ...a, fps: Number(e.target.value) || 30 }))}
+                            />
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <label className="text-sm font-medium text-gray-700">Emoji Font:</label>
+                            <select
+                                className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:ring-2 focus:ring-orange-300 focus:border-transparent"
+                                value={animation.emojiFont || ''}
+                                onChange={(e) =>
+                                    setAnimation((a) => ({
+                                        ...a,
+                                        emojiFont: e.target.value || undefined,
+                                    }))
+                                }
+                            >
+                                <option value="">System default</option>
+                                <option value="Noto Color Emoji">Noto Color Emoji</option>
+                                <option value="Twemoji">Twemoji</option>
+                                <option value="OpenMoji">OpenMoji</option>
+                                <option value="Blobmoji">Blobmoji</option>
+                                <option value="FxEmoji">FxEmoji</option>
+                            </select>
+                        </div>
+                        {channels.length > 1 && (
                             <div className="flex items-center gap-2">
-                                <ClockIcon size={16} className="text-gray-500" />
-                                <label className="text-sm font-medium text-gray-700">FPS:</label>
-                                <input
-                                    type="number"
-                                    className="border border-gray-300 rounded-md px-2 py-1 w-16 text-sm focus:ring-2 focus:ring-orange-300 focus:border-transparent"
-                                    value={animation.fps}
-                                    onChange={(e) => setAnimation((a) => ({ ...a, fps: Number(e.target.value) || 30 }))}
-                                />
-                            </div>
-                            {channels.length > 1 && (
-                                <div className="flex items-center gap-2">
-                                    <label className="text-sm font-medium text-gray-700">Channel:</label>
-                                    <select
-                                        className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:ring-2 focus:ring-orange-300 focus:border-transparent"
+                                <label className="text-sm font-medium text-gray-700">Channel:</label>
+                                <select
+                                    className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:ring-2 focus:ring-orange-300 focus:border-transparent"
                                         value={channelId || ''}
                                         onChange={(e) => setChannelId(e.target.value)}
                                     >
@@ -309,6 +330,7 @@ export default function MovieEditor({ movie }: MovieEditorProps) {
                                 onRemove={() => removeScene(activeSceneIndex)}
                                 onDuplicate={() => duplicateScene(activeSceneIndex)}
                                 sceneIndex={activeSceneIndex}
+                                emojiFont={animation.emojiFont}
                             />
                         ) : (
                             <div className="flex items-center justify-center h-64 text-gray-500">

--- a/components/SceneCanvas.tsx
+++ b/components/SceneCanvas.tsx
@@ -12,15 +12,18 @@ type SceneCanvasProps = {
     width: number;
     height: number;
     onSceneChange: (s: Scene) => void;
+    emojiFont?: string;
 };
 
-export default function SceneCanvas({ scene, fps, width, height, onSceneChange }: SceneCanvasProps) {
+export default function SceneCanvas({ scene, fps, width, height, onSceneChange, emojiFont }: SceneCanvasProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const [size, setSize] = useState({ w: 0, h: 0 });
     const [currentFrame, setCurrentFrame] = useState(0);
     const [selected, setSelected] = useState<string | null>(null);
     const [tool, setTool] = useState<'move' | 'scale' | 'rotate'>('move');
     const [layer, setLayer] = useState<'actors' | 'background'>('actors');
+
+    const emojiStyle = emojiFont ? { fontFamily: emojiFont } : undefined;
 
     const dragRef = useRef<{
         id: string;
@@ -342,7 +345,8 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange }
                                     position: 'absolute',
                                     left: offsetX,
                                     top: offsetY,
-                                    fontSize: partSize
+                                    fontSize: partSize,
+                                    fontFamily: emojiFont
                                 }}
                             >
                                 <span
@@ -407,7 +411,7 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange }
                 } ${interactive ? 'hover:ring-2 hover:ring-gray-300 hover:ring-offset-1' : ''}`}
                 style={style}
             >
-                {a.type === 'emoji' && <span>{(a as any).emoji}</span>}
+                {a.type === 'emoji' && <span style={emojiStyle}>{(a as any).emoji}</span>}
                 {a.type === 'text' && (
                     <span style={{ color: (a as TextActor).color }}>
             {(a as TextActor).text}

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -27,12 +27,13 @@ export type SceneEditorProps = {
     onRemove: () => void;
     onDuplicate: () => void;
     sceneIndex: number;
+    emojiFont?: string;
 };
 
 const CANVAS_WIDTH = 480;
 const CANVAS_HEIGHT = 270;
 
-export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicate, sceneIndex }: SceneEditorProps) {
+export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicate, sceneIndex, emojiFont }: SceneEditorProps) {
     const [activeSection, setActiveSection] = useState<'canvas' | 'actors' | 'background'>('canvas');
 
     const update = (fields: Partial<Scene>) => onChange({ ...scene, ...fields });
@@ -217,6 +218,7 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
                         width={CANVAS_WIDTH}
                         height={CANVAS_HEIGHT}
                         onSceneChange={onChange}
+                        emojiFont={emojiFont}
                     />
                 </div>
             )}
@@ -244,6 +246,7 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
                                 onChange={(ac) => updateBackground(i, ac as EmojiActor)}
                                 onRemove={() => removeBackground(i)}
                                 allowTypeChange={false}
+                                emojiFont={emojiFont}
                             />
                         ))}
                         {scene.backgroundActors.length === 0 && (
@@ -297,6 +300,7 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
                                 actor={a}
                                 onChange={(ac) => updateActor(i, ac)}
                                 onRemove={() => removeActor(i)}
+                                emojiFont={emojiFont}
                             />
                         ))}
                         {scene.actors.length === 0 && (


### PR DESCRIPTION
## Summary
- add optional `emojiFont` to animations
- allow picking emoji font in movie editor
- render chosen font across editor, player, and generated images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9f392171c832698170d42482cd85a