### PR TITLE
feat: add background color option to scene editor

### DIFF
--- a/app/api/og/[clipId]/route.tsx
+++ b/app/api/og/[clipId]/route.tsx
@@ -21,6 +21,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
   const scene: Scene | undefined = clip?.animation?.scenes?.[0];
   const emojiFont = clip?.animation?.emojiFont || clip?.emoji_font;
   const fonts = await fetchEmojiFontData(emojiFont);
+  const defaultBg = emojiFont === 'Noto Emoji' ? '#fff' : '#000';
   const width = 1200;
   const height = Math.round((width * 9) / 16);
   const baseUnit = width / 12.5;
@@ -135,7 +136,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            background: '#fff',
+            background: defaultBg,
             fontSize: Math.round(baseUnit * 1.5),
             fontWeight: 700,
           }}
@@ -158,7 +159,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
           position: 'relative',
           width: '100%',
           height: '100%',
-          background: '#fff',
+          background: scene.backgroundColor ?? defaultBg,
           display: 'flex',
         }}
       >

--- a/app/api/thumbnail/[clipId]/route.tsx
+++ b/app/api/thumbnail/[clipId]/route.tsx
@@ -21,6 +21,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
   const scene: Scene | undefined = clip?.animation?.scenes?.[0];
   const emojiFont = clip?.animation?.emojiFont || clip?.emoji_font;
   const fonts = await fetchEmojiFontData(emojiFont);
+  const defaultBg = emojiFont === 'Noto Emoji' ? '#fff' : '#000';
   const width = 400;
   const height = Math.round((width * 9) / 16);
   const title = clip?.title || 'Emoji Clip';
@@ -134,7 +135,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            background: '#fff',
+            background: defaultBg,
             fontSize: 48,
             fontWeight: 700,
           }}
@@ -157,7 +158,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
           position: 'relative',
           width: '100%',
           height: '100%',
-          background: '#fff',
+          background: scene.backgroundColor ?? defaultBg,
           display: 'flex',
         }}
       >

--- a/components/AnimationTypes.ts
+++ b/components/AnimationTypes.ts
@@ -58,6 +58,8 @@ export type Scene = {
   duration_ms: number; // scene duration
   backgroundActors: EmojiActor[]; // actors rendered behind foreground
   caption?: string;
+  /** Optional solid background color for the scene */
+  backgroundColor?: string;
   actors: Actor[];
   effects?: Effect[];
   sfx?: { at_ms: number; type: 'pop' | 'whoosh' | 'ding' }[];

--- a/components/EmojiPlayer.tsx
+++ b/components/EmojiPlayer.tsx
@@ -113,6 +113,7 @@ export const EmojiPlayer = forwardRef(function EmojiPlayer(
   const scene = animation.scenes[sceneIndex];
   const duration = Math.max(1, scene?.duration_ms ?? 1);
   const emojiStyle = animation.emojiFont ? { fontFamily: animation.emojiFont } : undefined;
+  const defaultBg = animation.emojiFont === 'Noto Emoji' ? '#ffffff' : '#000000';
 
   useEmojiFont(animation.emojiFont);
 
@@ -268,6 +269,7 @@ export const EmojiPlayer = forwardRef(function EmojiPlayer(
             height={height}
             progress={progress}
             emojiStyle={emojiStyle}
+            backgroundColor={scene.backgroundColor ?? defaultBg}
           />
         )}
 
@@ -360,16 +362,18 @@ function SceneView({
   width,
   height,
   progress,
-  emojiStyle
+  emojiStyle,
+  backgroundColor
 }: {
   scene: Scene;
   width: number;
   height: number;
   progress: number;
   emojiStyle?: React.CSSProperties;
+  backgroundColor: string;
 }) {
   const content = (
-    <div style={{ position: 'relative', width, height }}>
+    <div style={{ position: 'relative', width, height, backgroundColor }}>
       {scene.backgroundActors
         .slice()
         .sort((a, b) => (a.z ?? 0) - (b.z ?? 0))

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -15,6 +15,7 @@ import { useEmojiFont } from '../lib/emojiFonts';
 function SceneThumbnail({ scene, emojiFont }: { scene: Scene; emojiFont?: string }) {
   const width = 160;
   const height = (width * 9) / 16; // match EmojiPlayer aspect ratio
+  const defaultBg = emojiFont === 'Noto Emoji' ? '#ffffff' : '#000000';
 
   const renderEmoji = (a: EmojiActor) => {
     const start = a.start ?? {
@@ -129,8 +130,12 @@ function SceneThumbnail({ scene, emojiFont }: { scene: Scene; emojiFont?: string
 
   return (
     <div
-      className="relative bg-white rounded-md overflow-hidden border"
-      style={{ width, height }}
+      className="relative rounded-md overflow-hidden border"
+      style={{
+        width,
+        height,
+        backgroundColor: scene.backgroundColor ?? defaultBg,
+      }}
     >
       {scene.backgroundActors.map((a) => renderActor(a))}
       {scene.actors.map((a) => renderActor(a))}

--- a/components/SceneCanvas.tsx
+++ b/components/SceneCanvas.tsx
@@ -141,7 +141,8 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
 
     const findActor = (id: string) => {
         const list = layer === 'actors' ? scene.actors : scene.backgroundActors;
-        return list.find((a) => a.id === id)!;
+        const actor = list.find((a) => a.id === id);
+        return actor;
     };
 
     const handleMoveStart = (actorId: string, e: React.PointerEvent) => {
@@ -151,7 +152,9 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
         setSelected(actorId);
         const rect = containerRef.current.getBoundingClientRect();
         const t = Math.round(currentFrame * frameMs);
-        const pose = sample(findActor(actorId), t);
+        const actor = findActor(actorId);
+        if (!actor) return; // Safety check
+        const pose = sample(actor, t);
         const left = rect.left + pose.x * rect.width;
         const top = rect.top + pose.y * rect.height;
         const offsetX = e.clientX - left;
@@ -168,7 +171,9 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
         const x = clamp01((e.clientX - rect.left - offsetX) / rect.width);
         const y = clamp01((e.clientY - rect.top - offsetY) / rect.height);
         const t = Math.round(currentFrame * frameMs);
-        const pose = sample(findActor(id), t);
+        const actor = findActor(id);
+        if (!actor) return; // Safety check
+        const pose = sample(actor, t);
         updateActor(id, { t, x, y, scale: pose.scale, rotate: pose.rotate });
     };
 
@@ -183,7 +188,9 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
         e.stopPropagation();
         setSelected(actorId);
         const t = Math.round(currentFrame * frameMs);
-        const pose = sample(findActor(actorId), t);
+        const actor = findActor(actorId);
+        if (!actor) return; // Safety check
+        const pose = sample(actor, t);
         scaleRef.current = {
             id: actorId,
             startScale: pose.scale,
@@ -202,7 +209,9 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
         const diff = e.clientY - s.startY;
         const t = Math.round(currentFrame * frameMs);
         const newScale = Math.max(0.1, s.startScale + diff / 100);
-        const pose = sample(findActor(s.id), t);
+        const actor = findActor(s.id);
+        if (!actor) return; // Safety check
+        const pose = sample(actor, t);
         updateActor(s.id, { t, x: s.x, y: s.y, scale: newScale, rotate: pose.rotate });
     };
 
@@ -218,7 +227,9 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
         e.stopPropagation();
         setSelected(actorId);
         const t = Math.round(currentFrame * frameMs);
-        const pose = sample(findActor(actorId), t);
+        const actor = findActor(actorId);
+        if (!actor) return; // Safety check
+        const pose = sample(actor, t);
         const rect = containerRef.current.getBoundingClientRect();
         const centerX = rect.left + pose.x * rect.width;
         const centerY = rect.top + pose.y * rect.height;
@@ -252,7 +263,9 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
         const newRotation = r.startRotation + angleDiff;
 
         const t = Math.round(currentFrame * frameMs);
-        const pose = sample(findActor(r.id), t);
+        const actor = findActor(r.id);
+        if (!actor) return; // Safety check
+        const pose = sample(actor, t);
         updateActor(r.id, { t, x: r.x, y: r.y, scale: pose.scale, rotate: newRotation });
     };
 
@@ -435,6 +448,11 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
 
     const allActors: Actor[] = [...(scene.backgroundActors as Actor[]), ...scene.actors];
 
+    const handleLayerChange = (newLayer: 'actors' | 'background') => {
+        setLayer(newLayer);
+        setSelected(null); // Clear selection when switching layers
+    };
+
     return (
         <div className="space-y-4">
             {/* Controls */}
@@ -505,9 +523,14 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
                 )}
             </div>
 
-            {/* Actor Info */}
-            {selected && (
-                <SceneCanvasActorInfo actor={findActor(selected)} currentFrame={currentFrame} frameMs={frameMs} sample={sample} />
+            {/* Actor Info Panel */}
+            {selected && findActor(selected) && (
+                <SceneCanvasActorInfo
+                    actor={findActor(selected)!}
+                    currentFrame={currentFrame}
+                    frameMs={frameMs}
+                    sample={sample}
+                />
             )}
         </div>
     );

--- a/components/SceneCanvas.tsx
+++ b/components/SceneCanvas.tsx
@@ -24,6 +24,7 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
     const [layer, setLayer] = useState<'actors' | 'background'>('actors');
 
     const emojiStyle = emojiFont ? { fontFamily: emojiFont } : undefined;
+    const defaultBg = emojiFont === 'Noto Emoji' ? '#ffffff' : '#000000';
 
     const dragRef = useRef<{
         id: string;
@@ -465,11 +466,12 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
             {/* Canvas */}
             <div
                 ref={containerRef}
-                className="relative bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm"
+                className="relative border border-gray-200 rounded-lg overflow-hidden shadow-sm"
                 style={{
                     aspectRatio: `${width}/${height}`,
                     width: '100%',
-                    maxHeight: '400px'
+                    maxHeight: '400px',
+                    backgroundColor: scene.backgroundColor ?? defaultBg
                 }}
             >
                 {/* Background Actors */}

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -8,6 +8,7 @@ import {
     ArrowsOutCardinalIcon,
     UserIcon,
     MountainsIcon,
+    PaletteIcon,
     UsersIcon,
     PlusIcon,
     SmileyWinkIcon,
@@ -37,6 +38,7 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
     const [activeSection, setActiveSection] = useState<'canvas' | 'actors' | 'background'>('canvas');
 
     const update = (fields: Partial<Scene>) => onChange({ ...scene, ...fields });
+    const defaultBg = emojiFont === 'Noto Emoji' ? '#ffffff' : '#000000';
 
     const updateActor = (idx: number, actor: Actor) => {
         const actors = [...scene.actors];
@@ -142,7 +144,7 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
                         </button>
                     </div>
                 </div>
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-3 gap-4">
                     <div>
                         <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
                             <ClockIcon size={14} />
@@ -166,6 +168,26 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
                             placeholder="Optional caption..."
                             onChange={(e) => update({ caption: e.target.value })}
                         />
+                    </div>
+                    <div>
+                        <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+                            <PaletteIcon size={14} />
+                            Background
+                        </label>
+                        <div className="flex items-center gap-2">
+                            <input
+                                type="color"
+                                className="h-10 w-12 rounded-md border border-gray-300"
+                                value={scene.backgroundColor ?? defaultBg}
+                                onChange={(e) => update({ backgroundColor: e.target.value })}
+                            />
+                            <button
+                                className="text-xs text-gray-500 hover:text-gray-700"
+                                onClick={() => update({ backgroundColor: undefined })}
+                            >
+                                Reset
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- allow scenes to define an optional `backgroundColor`
- add color picker in scene editor with reset
- render scene background color in editor and player, defaulting to black or white for Noto Emoji

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68baa31fbad48326bf8bf9d4e1ab32c8