### PR TITLE
Add hero heading and create button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,28 +18,28 @@ export default function Page() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100">
-      <div className="max-w-4xl mx-auto px-6 py-8">
+      <div className="max-w-4xl mx-auto px-6 py-4">
         {/* Header */}
-        <div className="text-center mb-8">
-          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 flex items-center justify-center gap-3 mb-2">
+        <div className="text-center mb-4">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 flex items-center justify-center gap-3 mb-1">
             <div className="p-2 bg-gradient-to-br from-blue-500 to-purple-600 rounded-xl shadow-lg">
-              <FilmSlate weight="bold" size={36} className="text-white" />
+              <FilmSlate weight="bold" size={32} className="text-white" />
             </div>
             Emoji Movie Studio
           </h1>
           <p className="text-gray-600 text-lg max-w-2xl mx-auto">
-            Transform your stories into animated emoji movies using AI
+            Create AI-powered emoji movies from your stories
           </p>
         </div>
 
         {/* Call to Action */}
-        <div className="flex justify-center mb-8">
+        <div className="flex justify-center mb-6">
           <button
             onClick={() => router.push('/create')}
             className="group flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white rounded-xl shadow-md hover:shadow-lg transition-all duration-200 font-medium"
           >
             <MagicWand weight="bold" size={20} className="group-hover:scale-110 transition-transform" />
-            Generate with AI
+            Create
           </button>
         </div>
 
@@ -57,7 +57,7 @@ export default function Page() {
         )}
 
         {movies.length > 0 && (
-          <div className="mt-12">
+          <div className="mt-8">
             <h2 className="text-2xl font-bold mb-4 text-center">Latest Movies</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
               {movies.map((m) => (


### PR DESCRIPTION
## Summary
- Add compact hero section with centered heading and tagline for Emoji Movie Studio
- Add prominent "Create" button linking to `/create`
- Reduce hero spacing so video feed appears above the fold

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bab852a83883269d85ec6e7ef5a463