### PR TITLE
feat: improve movie feed

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 
 /* eslint-disable import/no-unresolved */
 import { FilmSlate, MagicWand } from '@phosphor-icons/react';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { MovieCard } from '../components/MovieCard';
 import { getAllMovies } from '../lib/supabaseClient';
@@ -10,7 +10,7 @@ import { getAllMovies } from '../lib/supabaseClient';
 export default function Page() {
   const [movies, setMovies] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [page, setPage] = useState(0);
+  const pageRef = useRef(0);
   const [loading, setLoading] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const router = useRouter();
@@ -20,25 +20,25 @@ export default function Page() {
     if (loading || !hasMore) return;
     setLoading(true);
     try {
-      const newMovies = await getAllMovies({
-        from: page * pageSize,
-        to: page * pageSize + pageSize - 1,
-      });
+      const from = pageRef.current * pageSize;
+      const to = from + pageSize - 1;
+      const newMovies = await getAllMovies({ from, to });
       setMovies((prev) => [...prev, ...newMovies]);
       if (newMovies.length < pageSize) {
         setHasMore(false);
       }
-      setPage((p) => p + 1);
+      pageRef.current += 1;
     } catch (e: any) {
       setError(e.message);
     } finally {
       setLoading(false);
     }
-  }, [page, pageSize, loading, hasMore]);
+  }, [pageSize, loading, hasMore]);
 
   useEffect(() => {
     loadMore();
-  }, [loadMore]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     const handleScroll = () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ export default function Page() {
   const [movies, setMovies] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
   const pageRef = useRef(0);
+  const loadedIds = useRef(new Set<string>());
   const [loading, setLoading] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const router = useRouter();
@@ -23,7 +24,9 @@ export default function Page() {
       const from = pageRef.current * pageSize;
       const to = from + pageSize - 1;
       const newMovies = await getAllMovies({ from, to });
-      setMovies((prev) => [...prev, ...newMovies]);
+      const unique = newMovies.filter((m) => !loadedIds.current.has(m.id));
+      unique.forEach((m) => loadedIds.current.add(m.id));
+      setMovies((prev) => [...prev, ...unique]);
       if (newMovies.length < pageSize) {
         setHasMore(false);
       }

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { HeartIcon } from '@phosphor-icons/react';
+import { HeartIcon, TelevisionSimpleIcon } from '@phosphor-icons/react';
 import { ShareButton } from './ShareButton';
 import type {
   Animation,
@@ -181,7 +181,9 @@ export function MovieCard({
     <div className="flex flex-col">
       {firstScene ? (
         <SceneThumbnail scene={firstScene} emojiFont={emojiFont} />
-      ) : null}
+      ) : (
+        <div className="w-full aspect-video rounded-md bg-gray-200" />
+      )}
       <div className="mt-2 flex flex-col gap-1">
         <div className="text-sm font-semibold leading-tight line-clamp-2">
           {movie.title || movie.story.slice(0, 30)}
@@ -189,13 +191,19 @@ export function MovieCard({
         {movie.channels ? (
           <Link
             href={`/channel/${encodeURIComponent(movie.channels.name)}`}
-            className="text-xs text-gray-500 truncate hover:text-gray-700"
+            className="group inline-flex items-center gap-1 text-xs text-gray-500 truncate hover:text-gray-700"
             onClick={(e) => e.stopPropagation()}
           >
-            @{movie.channels.name}
+            <TelevisionSimpleIcon weight="bold" className="group-hover:text-gray-700" />
+            <span className="truncate">@{movie.channels.name}</span>
           </Link>
         ) : (
           <div className="text-xs text-gray-500 truncate">Unknown channel</div>
+        )}
+        {movie.description && (
+          <div className="text-xs text-gray-500 truncate">
+            {movie.description}
+          </div>
         )}
         <div className="flex items-center gap-2 mt-1">
           <button

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { HeartIcon, TelevisionSimpleIcon } from '@phosphor-icons/react';
@@ -8,6 +10,7 @@ import type {
   Actor,
   EmojiActor,
   CompositeActor,
+  TextActor,
 } from './AnimationTypes';
 import { likeMovie, getMovieLikes } from '../lib/supabaseClient';
 import { useEmojiFont } from '../lib/emojiFonts';
@@ -49,9 +52,39 @@ function SceneThumbnail({ scene, emojiFont }: { scene: Scene; emojiFont?: string
     );
   };
 
+  const renderText = (a: TextActor) => {
+    const first = a.tracks?.[0];
+    const start =
+      a.start ||
+      (first
+        ? { x: first.x, y: first.y, scale: first.scale ?? 1 }
+        : { x: 0, y: 0, scale: 1 });
+    const size = a.fontSize ?? Math.round(32 * start.scale);
+    const left = start.x * 100;
+    const top = start.y * 100;
+    return (
+      <span
+        key={a.id}
+        style={{
+          position: 'absolute',
+          left: `${left}%`,
+          top: `${top}%`,
+          fontSize: size,
+          transform: 'translate(-50%, -50%)',
+          color: a.color || '#000',
+        }}
+      >
+        {a.text}
+      </span>
+    );
+  };
+
   const renderActor = (actor: Actor): React.ReactNode => {
     if (actor.type === 'emoji') {
       return renderEmoji(actor);
+    }
+    if (actor.type === 'text') {
+      return renderText(actor);
     }
     if (actor.type === 'composite') {
       const comp = actor as CompositeActor;

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { HeartIcon, TelevisionSimpleIcon } from '@phosphor-icons/react';
+import { HeartIcon } from '@phosphor-icons/react';
 import { ShareButton } from './ShareButton';
 import type {
   Animation,
@@ -13,8 +13,6 @@ import { likeMovie, getMovieLikes } from '../lib/supabaseClient';
 import { useEmojiFont } from '../lib/emojiFonts';
 
 function SceneThumbnail({ scene, emojiFont }: { scene: Scene; emojiFont?: string }) {
-  const width = 160;
-  const height = (width * 9) / 16; // match EmojiPlayer aspect ratio
   const defaultBg = emojiFont === 'Noto Emoji' ? '#ffffff' : '#000000';
 
   const renderEmoji = (a: EmojiActor) => {
@@ -130,12 +128,8 @@ function SceneThumbnail({ scene, emojiFont }: { scene: Scene; emojiFont?: string
 
   return (
     <div
-      className="relative rounded-md overflow-hidden border"
-      style={{
-        width,
-        height,
-        backgroundColor: scene.backgroundColor ?? defaultBg,
-      }}
+      className="relative w-full aspect-video rounded-md overflow-hidden border"
+      style={{ backgroundColor: scene.backgroundColor ?? defaultBg }}
     >
       {scene.backgroundActors.map((a) => renderActor(a))}
       {scene.actors.map((a) => renderActor(a))}
@@ -184,28 +178,26 @@ export function MovieCard({
   };
 
   return (
-    <div className="space-y-2">
+    <div className="flex flex-col">
       {firstScene ? (
         <SceneThumbnail scene={firstScene} emojiFont={emojiFont} />
       ) : null}
-      <div className="space-y-1">
-        <div className="text-sm font-medium truncate">
+      <div className="mt-2 flex flex-col gap-1">
+        <div className="text-sm font-semibold leading-tight line-clamp-2">
           {movie.title || movie.story.slice(0, 30)}
         </div>
-        {movie.description && (
-          <div className="text-xs text-gray-500 truncate">{movie.description}</div>
-        )}
-        {movie.channels && (
+        {movie.channels ? (
           <Link
             href={`/channel/${encodeURIComponent(movie.channels.name)}`}
-            className="group inline-flex items-center gap-1 px-2 py-1 bg-gradient-to-r from-orange-50 to-yellow-50 hover:from-orange-100 hover:to-orange-100 border border-orange-400 hover:border-orange-500 rounded-full text-xs font-medium text-orange-400 hover:text-orange-500 transition-all duration-200 shadow-sm hover:shadow-md max-w-fit"
+            className="text-xs text-gray-500 truncate hover:text-gray-700"
             onClick={(e) => e.stopPropagation()}
           >
-            <TelevisionSimpleIcon weight="bold"></TelevisionSimpleIcon>
-            <span className="truncate">@{movie.channels.name}</span>
+            @{movie.channels.name}
           </Link>
+        ) : (
+          <div className="text-xs text-gray-500 truncate">Unknown channel</div>
         )}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 mt-1">
           <button
             onClick={toggleLike}
             className={`flex items-center gap-1 text-xs ${liked ? 'text-orange-400' : 'text-gray-500'}`}

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -131,8 +131,8 @@ function SceneThumbnail({ scene, emojiFont }: { scene: Scene; emojiFont?: string
       className="relative w-full aspect-video rounded-md overflow-hidden border"
       style={{ backgroundColor: scene.backgroundColor ?? defaultBg }}
     >
-      {scene.backgroundActors.map((a) => renderActor(a))}
-      {scene.actors.map((a) => renderActor(a))}
+      {(scene.backgroundActors || []).map((a) => renderActor(a))}
+      {(scene.actors || []).map((a) => renderActor(a))}
     </div>
   );
 }
@@ -145,17 +145,21 @@ export function MovieCard({
     title?: string;
     description?: string;
     story: string;
-    animation: Animation;
+    animation: Animation | string;
     channels?: {
       name: string;
       user_id: string;
     };
   };
 }) {
-  const firstScene = movie.animation?.scenes?.[0];
+  const animation =
+    typeof movie.animation === 'string'
+      ? JSON.parse(movie.animation)
+      : movie.animation;
+  const firstScene = animation?.scenes?.[0];
   const [likes, setLikes] = useState(0);
   const [liked, setLiked] = useState(false);
-  const emojiFont = movie.animation?.emojiFont || (movie as any).emoji_font;
+  const emojiFont = animation?.emojiFont || (movie as any).emoji_font;
 
   useEmojiFont(emojiFont);
 

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -16,11 +16,12 @@ function SceneThumbnail({ scene, emojiFont }: { scene: Scene; emojiFont?: string
   const defaultBg = emojiFont === 'Noto Emoji' ? '#ffffff' : '#000000';
 
   const renderEmoji = (a: EmojiActor) => {
-    const start = a.start ?? {
-      x: a.tracks[0].x,
-      y: a.tracks[0].y,
-      scale: a.tracks[0].scale ?? 1,
-    };
+    const first = a.tracks?.[0];
+    const start =
+      a.start ||
+      (first
+        ? { x: first.x, y: first.y, scale: first.scale ?? 1 }
+        : { x: 0, y: 0, scale: 1 });
     const size = Math.round(32 * start.scale);
     const left = start.x * 100;
     const top = start.y * 100;
@@ -77,7 +78,8 @@ function SceneThumbnail({ scene, emojiFont }: { scene: Scene; emojiFont?: string
 
       const widthP = (maxX - minX) * unitSize;
       const heightP = (maxY - minY) * unitSize;
-      const pos = comp.start ?? { x: comp.tracks[0].x, y: comp.tracks[0].y };
+      const first = comp.tracks?.[0];
+      const pos = comp.start ?? (first ? { x: first.x, y: first.y } : { x: 0, y: 0 });
       const left = pos.x * 100;
       const top = pos.y * 100;
 
@@ -152,10 +154,16 @@ export function MovieCard({
     };
   };
 }) {
-  const animation =
-    typeof movie.animation === 'string'
-      ? JSON.parse(movie.animation)
-      : movie.animation;
+  let animation: Animation | null = null;
+  if (typeof movie.animation === 'string') {
+    try {
+      animation = JSON.parse(movie.animation);
+    } catch {
+      animation = null;
+    }
+  } else {
+    animation = movie.animation;
+  }
   const firstScene = animation?.scenes?.[0];
   const [likes, setLikes] = useState(0);
   const [liked, setLiked] = useState(false);

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -156,11 +156,17 @@ export function MovieCard({
 }) {
   let animation: Animation | null = null;
   if (typeof movie.animation === 'string') {
-    try {
-      animation = JSON.parse(movie.animation);
-    } catch {
-      animation = null;
+    let anim: any = movie.animation;
+    // Handle double-encoded JSON strings by parsing until it's an object.
+    while (typeof anim === 'string') {
+      try {
+        anim = JSON.parse(anim);
+      } catch {
+        anim = null;
+        break;
+      }
     }
+    animation = anim;
   } else {
     animation = movie.animation;
   }

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -192,13 +192,17 @@ export async function getAllMovies(range?: { from?: number; to?: number }) {
 
   const { data, error } = await query;
 
-  const parseAnimation = (movie: any) => ({
-    ...movie,
-    animation:
-      typeof movie.animation === 'string'
-        ? JSON.parse(movie.animation)
-        : movie.animation,
-  });
+  const parseAnimation = (movie: any) => {
+    let animation = movie.animation;
+    if (typeof animation === 'string') {
+      try {
+        animation = JSON.parse(animation);
+      } catch {
+        animation = null;
+      }
+    }
+    return { ...movie, animation };
+  };
 
   if (error) {
     // If the foreign key approach doesn't work, fall back to manual join

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -194,11 +194,14 @@ export async function getAllMovies(range?: { from?: number; to?: number }) {
 
   const parseAnimation = (movie: any) => {
     let animation = movie.animation;
-    if (typeof animation === 'string') {
+    // Some rows store the animation JSON double-encoded as a string.
+    // Parse repeatedly until we get an object or hit a parsing error.
+    while (typeof animation === 'string') {
       try {
         animation = JSON.parse(animation);
       } catch {
         animation = null;
+        break;
       }
     }
     return { ...movie, animation };


### PR DESCRIPTION
## Summary
- move "Latest Movies" above creation tools and show more videos as you scroll
- display movies in a responsive grid with thumbnails, titles, and channels
- paginate movie queries for incremental loading

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68babaab85e88326a1f20d11b30f9220