### PR TITLE
Show placeholders for empty sections and log movie plays

### DIFF
--- a/Supabase.sql
+++ b/Supabase.sql
@@ -86,6 +86,25 @@ create policy "Users can insert their own likes" on public.likes
 create policy "Users can delete their own likes" on public.likes
   for delete using (auth.uid() = user_id);
 
+-- Plays table for tracking movie play events
+create table if not exists public.plays (
+  id uuid primary key default gen_random_uuid(),
+  movie_id uuid references public.movies(id) on delete cascade,
+  user_id uuid references auth.users(id),
+  created_at timestamptz default now()
+);
+
+alter table public.plays enable row level security;
+
+create policy "Public read access" on public.plays
+  for select using (true);
+
+create policy "Allow anonymous plays" on public.plays
+  for insert with check (auth.uid() is null and user_id is null);
+
+create policy "Users can insert their own plays" on public.plays
+  for insert with check (auth.uid() = user_id);
+
 -- Comments table for movie comments
 create table if not exists public.comments (
   id uuid primary key default gen_random_uuid(),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,10 +5,17 @@ import { FilmSlate, MagicWand } from '@phosphor-icons/react';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { MovieCard } from '../components/MovieCard';
-import { getAllMovies } from '../lib/supabaseClient';
+import {
+  getAllMovies,
+  getTrendingMovies,
+  getRecommendedMovies,
+} from '../lib/supabaseClient';
 
 export default function Page() {
   const [movies, setMovies] = useState<any[]>([]);
+  const [trending, setTrending] = useState<any[]>([]);
+  const [recommended, setRecommended] = useState<any[]>([]);
+  const [extrasLoaded, setExtrasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pageRef = useRef(0);
   const loadedIds = useRef(new Set<string>());
@@ -41,6 +48,24 @@ export default function Page() {
   useEffect(() => {
     loadMore();
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const fetchExtras = async () => {
+      try {
+        const [trend, rec] = await Promise.all([
+          getTrendingMovies(),
+          getRecommendedMovies(),
+        ]);
+        setTrending(trend);
+        setRecommended(rec);
+      } catch {
+        // ignore
+      } finally {
+        setExtrasLoaded(true);
+      }
+    };
+    fetchExtras();
   }, []);
 
   useEffect(() => {
@@ -117,6 +142,66 @@ export default function Page() {
             )}
           </div>
         )}
+
+        
+<div className="mt-12">
+  <h2 className="text-2xl font-bold mb-4 text-center">Trending</h2>
+  {trending.length > 0 ? (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+      {trending.map((m) => (
+        <div
+          key={m.id}
+          onClick={(e) => {
+            const target = e.target as HTMLElement;
+            if (!target.closest('a,button')) {
+              router.push(`/movies/${m.id}`);
+            }
+          }}
+          className="cursor-pointer"
+        >
+          <MovieCard movie={m} />
+        </div>
+      ))}
+    </div>
+  ) : (
+    extrasLoaded && (
+      <p className="text-center text-gray-600">
+        No trending movies yet.
+      </p>
+    )
+  )}
+</div>
+
+
+        
+<div className="mt-12">
+  <h2 className="text-2xl font-bold mb-4 text-center">Recommended for You</h2>
+  {recommended.length > 0 ? (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+      {recommended.map((m) => (
+        <div
+          key={m.id}
+          onClick={(e) => {
+            const target = e.target as HTMLElement;
+            if (!target.closest('a,button')) {
+              router.push(`/movies/${m.id}`);
+            }
+          }}
+          className="cursor-pointer"
+        >
+          <MovieCard movie={m} />
+        </div>
+      ))}
+    </div>
+  ) : (
+    extrasLoaded && (
+      <p className="text-center text-gray-600">
+        Sign in or like movies to see recommendations.
+      </p>
+    )
+  )}
+</div>
+
 
         {/* Call to Action */}
         <div className="flex justify-center mt-12 mb-6">

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { HeartIcon, TelevisionSimpleIcon } from '@phosphor-icons/react';
+import { HeartIcon, PlayIcon, TelevisionSimpleIcon } from '@phosphor-icons/react';
 import { ShareButton } from './ShareButton';
 import type {
   Animation,
@@ -12,7 +12,8 @@ import type {
   CompositeActor,
   TextActor,
 } from './AnimationTypes';
-import { likeMovie, getMovieLikes } from '../lib/supabaseClient';
+import { likeMovie, getMovieLikes, getMoviePlays } from '../lib/supabaseClient';
+import { formatCount } from '../lib/format';
 import { useEmojiFont } from '../lib/emojiFonts';
 
 function SceneThumbnail({ scene, emojiFont }: { scene: Scene; emojiFont?: string }) {
@@ -215,6 +216,7 @@ export function MovieCard({
   const firstScene = Array.isArray((animation as any)?.scenes)
     ? ((animation as any).scenes[0] as Scene)
     : undefined;
+  const [plays, setPlays] = useState(0);
   const [likes, setLikes] = useState(0);
   const [liked, setLiked] = useState(false);
   const emojiFont = animation?.emojiFont || (movie as any).emoji_font;
@@ -226,6 +228,7 @@ export function MovieCard({
       setLikes(count);
       setLiked(liked);
     });
+    getMoviePlays(movie.id).then(setPlays);
   }, [movie.id]);
 
   const toggleLike = async (e: React.MouseEvent) => {
@@ -268,6 +271,10 @@ export function MovieCard({
           </div>
         )}
         <div className="flex items-center gap-2 mt-1">
+          <div className="flex items-center gap-1 text-xs text-gray-500">
+            <PlayIcon size={14} />
+            <span>{formatCount(plays)}</span>
+          </div>
           <button
             onClick={toggleLike}
             className={`flex items-center gap-1 text-xs ${liked ? 'text-orange-400' : 'text-gray-500'}`}

--- a/components/MovieDetail.tsx
+++ b/components/MovieDetail.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { ArrowLeftIcon, HeartIcon } from '@phosphor-icons/react';
+import { ArrowLeftIcon, HeartIcon, PlayIcon } from '@phosphor-icons/react';
 import type { Animation } from './AnimationTypes';
 import { EmojiPlayer } from './EmojiPlayer';
 import { ClipComments } from './ClipComments';
@@ -13,10 +13,13 @@ import {
   getMovieLikes,
   getUserChannels,
   recordPlay,
+  getMoviePlays,
 } from '../lib/supabaseClient';
+import { formatCount } from '../lib/format';
 
 export default function MovieDetail({ movie }: { movie: any }) {
   const router = useRouter();
+  const [plays, setPlays] = useState(0);
   const [likes, setLikes] = useState(0);
   const [liked, setLiked] = useState(false);
   const [authorChannel, setAuthorChannel] = useState<string | null>(null);
@@ -29,9 +32,12 @@ export default function MovieDetail({ movie }: { movie: any }) {
         setLikes(count);
         setLiked(liked);
       });
+      getMoviePlays(movie.id).then(setPlays);
       if (!hasRecorded.current) {
         hasRecorded.current = true;
-        recordPlay(movie.id).catch(() => {});
+        recordPlay(movie.id)
+          .then(() => setPlays((p) => p + 1))
+          .catch(() => {});
       }
     }
     if (movie?.user_id) {
@@ -84,6 +90,10 @@ export default function MovieDetail({ movie }: { movie: any }) {
             </Link>
           </div>
           <div className="mt-4 flex justify-center gap-2">
+            <div className="flex items-center gap-2 px-4 py-2 rounded-lg border text-gray-600 border-gray-300">
+              <PlayIcon />
+              <span>{formatCount(plays)}</span>
+            </div>
             <button
               onClick={toggleLike}
               className={`flex items-center gap-2 px-4 py-2 rounded-lg border ${liked ? 'text-orange-400 border-orange-400 bg-red-50' : 'text-gray-600 border-gray-300'}`}

--- a/components/MovieDetail.tsx
+++ b/components/MovieDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { ArrowLeftIcon, HeartIcon } from '@phosphor-icons/react';
@@ -21,20 +21,25 @@ export default function MovieDetail({ movie }: { movie: any }) {
   const [liked, setLiked] = useState(false);
   const [authorChannel, setAuthorChannel] = useState<string | null>(null);
 
+  const hasRecorded = useRef(false);
+
   useEffect(() => {
     if (movie?.id) {
       getMovieLikes(movie.id).then(({ count, liked }) => {
         setLikes(count);
         setLiked(liked);
       });
-      recordPlay(movie.id).catch(() => {});
+      if (!hasRecorded.current) {
+        hasRecorded.current = true;
+        recordPlay(movie.id).catch(() => {});
+      }
     }
     if (movie?.user_id) {
       getUserChannels(movie.user_id)
         .then((chs) => setAuthorChannel(chs?.[0]?.name || null))
         .catch(() => setAuthorChannel(null));
     }
-  }, [movie]);
+  }, [movie?.id, movie?.user_id]);
 
   const toggleLike = async () => {
     if (!movie?.id) return;

--- a/components/MovieDetail.tsx
+++ b/components/MovieDetail.tsx
@@ -8,7 +8,12 @@ import type { Animation } from './AnimationTypes';
 import { EmojiPlayer } from './EmojiPlayer';
 import { ClipComments } from './ClipComments';
 import { ShareButton } from './ShareButton';
-import { likeMovie, getMovieLikes, getUserChannels } from '../lib/supabaseClient';
+import {
+  likeMovie,
+  getMovieLikes,
+  getUserChannels,
+  recordPlay,
+} from '../lib/supabaseClient';
 
 export default function MovieDetail({ movie }: { movie: any }) {
   const router = useRouter();
@@ -22,6 +27,7 @@ export default function MovieDetail({ movie }: { movie: any }) {
         setLikes(count);
         setLiked(liked);
       });
+      recordPlay(movie.id).catch(() => {});
     }
     if (movie?.user_id) {
       getUserChannels(movie.user_id)

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,6 @@
+export function formatCount(count: number): string {
+  if (count < 1000) return count.toString();
+  const k = count / 1000;
+  const decimals = k < 10 ? 1 : 0;
+  return `${parseFloat(k.toFixed(decimals))}k`;
+}

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -515,10 +515,10 @@ export async function getChannelWithMovies(name: string) {
   return { channel, movies: (movies || []).map((m) => ({ ...m, channels: channel })) };
 }
 
-export async function recordPlay(movieId: string) {
-  const user = await getUser();
+export const recordPlay = async (movieId: string) => {
+  const user = await getUser().catch(() => null);
   const { error } = await supabase
     .from('plays')
     .insert({ movie_id: movieId, user_id: user?.id ?? null });
   if (error) throw error;
-}
+};

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -410,6 +410,15 @@ export async function getMovieLikes(movieId: string) {
   return { count, liked };
 }
 
+export async function getMoviePlays(movieId: string) {
+  const { data, error } = await supabase
+    .from('plays')
+    .select('id')
+    .eq('movie_id', movieId);
+  if (error) throw error;
+  return data.length;
+}
+
 export async function postComment(movieId: string, content: string) {
   const user = await getUser();
   if (!user) throw new Error('Not authenticated');

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -6,6 +6,34 @@ const supabase = createBrowserClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 );
+const deepParse = (value: any): any => {
+  if (typeof value === 'string') {
+    try {
+      return deepParse(JSON.parse(value));
+    } catch {
+      return value;
+    }
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => deepParse(v));
+  }
+  if (value && typeof value === 'object') {
+    const result: any = {};
+    for (const [k, v] of Object.entries(value)) {
+      result[k] = deepParse(v);
+    }
+    return result;
+  }
+  return value;
+};
+
+const parseAnimation = (movie: any) => {
+  const parsed = deepParse(movie.animation);
+  return {
+    ...movie,
+    animation: typeof parsed === 'object' ? parsed : null,
+  };
+};
 
 export async function signUp(email: string, password: string) {
   const { error } = await supabase.auth.signUp({ email, password });
@@ -192,35 +220,6 @@ export async function getAllMovies(range?: { from?: number; to?: number }) {
 
   const { data, error } = await query;
 
-  const deepParse = (value: any): any => {
-    if (typeof value === 'string') {
-      try {
-        return deepParse(JSON.parse(value));
-      } catch {
-        return value;
-      }
-    }
-    if (Array.isArray(value)) {
-      return value.map((v) => deepParse(v));
-    }
-    if (value && typeof value === 'object') {
-      const result: any = {};
-      for (const [k, v] of Object.entries(value)) {
-        result[k] = deepParse(v);
-      }
-      return result;
-    }
-    return value;
-  };
-
-  const parseAnimation = (movie: any) => {
-    const parsed = deepParse(movie.animation);
-    return {
-      ...movie,
-      animation: typeof parsed === 'object' ? parsed : null,
-    };
-  };
-
   if (error) {
     // If the foreign key approach doesn't work, fall back to manual join
     let moviesQuery = supabase
@@ -270,6 +269,53 @@ export async function getAllMovies(range?: { from?: number; to?: number }) {
   return (data || []).map(parseAnimation);
 }
 
+export async function getTrendingMovies(limit = 8) {
+  const { data, error } = await supabase
+    .from('movies')
+    .select(`
+      *,
+      channels!movies_channel_id_fkey(
+        id,
+        name,
+        user_id
+      ),
+      likes(user_id)
+    `)
+    .not('publish_datetime', 'is', null)
+    .lte('publish_datetime', new Date().toISOString())
+    .limit(50);
+  if (error) throw error;
+  const movies = (data || []).map(parseAnimation);
+  movies.sort((a, b) => (b.likes?.length || 0) - (a.likes?.length || 0));
+  return movies.slice(0, limit);
+}
+
+export async function getRecommendedMovies(limit = 8) {
+  const user = await getUser();
+  if (!user) return [];
+  const { data, error } = await supabase
+    .from('movies')
+    .select(`
+      *,
+      channels!movies_channel_id_fkey(
+        id,
+        name,
+        user_id
+      ),
+      likes(user_id)
+    `)
+    .not('publish_datetime', 'is', null)
+    .lte('publish_datetime', new Date().toISOString())
+    .neq('user_id', user.id)
+    .limit(50);
+  if (error) throw error;
+  const movies = (data || []).map(parseAnimation);
+  const filtered = movies.filter(
+    (m) => !(m.likes || []).some((l: any) => l.user_id === user.id)
+  );
+  filtered.sort((a, b) => (b.likes?.length || 0) - (a.likes?.length || 0));
+  return filtered.slice(0, limit);
+}
 export async function searchMovies(query: string) {
   const { data, error } = await supabase
     .from('movies')
@@ -467,4 +513,12 @@ export async function getChannelWithMovies(name: string) {
     .order('created_at', { ascending: false });
   if (moviesError) throw moviesError;
   return { channel, movies: (movies || []).map((m) => ({ ...m, channels: channel })) };
+}
+
+export async function recordPlay(movieId: string) {
+  const user = await getUser();
+  const { error } = await supabase
+    .from('plays')
+    .insert({ movie_id: movieId, user_id: user?.id ?? null });
+  if (error) throw error;
 }


### PR DESCRIPTION
## Summary
- Always render trending and recommended sections on the homepage
- Display fallback text when no movies or recommendations are available
- Record movie play events in a new `plays` table for authenticated and anonymous users

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to collect page data for /api/storyboard due to missing OpenAI API key)*

------
https://chatgpt.com/codex/tasks/task_e_68bad9fd998c8326b5ba768e0c449870