### PR TITLE
Scale actors relative to viewport width

### DIFF
--- a/app/api/og/[clipId]/route.tsx
+++ b/app/api/og/[clipId]/route.tsx
@@ -24,7 +24,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
   const defaultBg = emojiFont === 'Noto Emoji' ? '#fff' : '#000';
   const width = 1200;
   const height = Math.round((width * 9) / 16);
-  const baseUnit = width / 12.5;
+  const baseUnit = width / 10;
   const title = clip?.title || 'Emoji Clip';
 
   function renderEmoji(a: EmojiActor) {

--- a/app/api/thumbnail/[clipId]/route.tsx
+++ b/app/api/thumbnail/[clipId]/route.tsx
@@ -24,6 +24,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
   const defaultBg = emojiFont === 'Noto Emoji' ? '#fff' : '#000';
   const width = 400;
   const height = Math.round((width * 9) / 16);
+  const baseUnit = width / 10;
   const title = clip?.title || 'Emoji Clip';
 
   function renderEmoji(a: EmojiActor) {
@@ -32,7 +33,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
       y: a.tracks[0].y,
       scale: a.tracks[0].scale ?? 1,
     };
-    const size = Math.round(32 * start.scale);
+    const size = Math.round(baseUnit * start.scale);
     const left = start.x * width - size / 2;
     const top = start.y * height - size / 2;
     return (
@@ -74,10 +75,12 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
         maxY = Math.max(maxY, y0 + s);
       }
 
-      const dominant = Math.max(...comp.parts.map((p) => p.start?.scale ?? 1));
+      const dominant = Math.max(
+        ...comp.parts.map((p) => p.start?.scale ?? 1)
+      );
       const unitSize =
         comp.meta?.sizeOverride ??
-        Math.round((32 * (comp.start?.scale ?? 1)) / dominant);
+        Math.round((baseUnit * (comp.start?.scale ?? 1)) / dominant);
 
       const widthP = (maxX - minX) * unitSize;
       const heightP = (maxY - minY) * unitSize;
@@ -136,7 +139,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
             alignItems: 'center',
             justifyContent: 'center',
             background: defaultBg,
-            fontSize: 48,
+            fontSize: Math.round(baseUnit * 1.2),
             fontWeight: 700,
           }}
         >
@@ -171,7 +174,7 @@ export async function GET(request: Request, { params }: { params: { clipId: stri
             left: 0,
             width: '100%',
             padding: '12px 16px',
-            fontSize: 32,
+            fontSize: Math.round(baseUnit * 0.8),
             fontWeight: 700,
             textAlign: 'center',
             background:

--- a/components/EmojiPlayer.tsx
+++ b/components/EmojiPlayer.tsx
@@ -416,7 +416,7 @@ function SceneView({
 
 function ActorView({
   actor,
-  w: _w,
+  w,
   h: _h,
   duration,
   progress,
@@ -429,6 +429,8 @@ function ActorView({
   progress: number;
   emojiStyle?: React.CSSProperties;
 }) {
+  const baseEmojiSize = w / 10;
+  const baseTextSize = w / 15;
   const frames = [
     actor.start && {
       t: 0,
@@ -454,7 +456,7 @@ function ActorView({
   const scale = sampleAt(times, scaleVals, progress);
 
   if (actor.type === 'emoji') {
-    const size = Math.round(48 * (actor.start?.scale ?? 1));
+    const size = Math.round(baseEmojiSize * (actor.start?.scale ?? 1));
     const node = (
       <span
         role="img"
@@ -477,7 +479,8 @@ function ActorView({
     return wrapWithEffects(node, actor.effects, 'span');
   }
   if (actor.type === 'text') {
-    const size = actor.fontSize ?? Math.round(32 * (actor.start?.scale ?? 1));
+    const size =
+      actor.fontSize ?? Math.round(baseTextSize * (actor.start?.scale ?? 1));
     const node = (
       <span
         style={{
@@ -517,9 +520,12 @@ function ActorView({
     const bbox = { minX, minY, maxX, maxY };
 
     // Dominant part determines base scale
-    const dominantScale = Math.max(...actor.parts.map((p) => p.start?.scale ?? 1));
+    const dominantScale = Math.max(
+      ...actor.parts.map((p) => p.start?.scale ?? 1)
+    );
     const unitSize =
-      actor.meta?.sizeOverride ?? Math.round((48 * (actor.start?.scale ?? 1)) / dominantScale);
+      actor.meta?.sizeOverride ??
+      Math.round((baseEmojiSize * (actor.start?.scale ?? 1)) / dominantScale);
 
     const width = (bbox.maxX - bbox.minX) * unitSize;
     const height = (bbox.maxY - bbox.minY) * unitSize;

--- a/components/SceneCanvas.tsx
+++ b/components/SceneCanvas.tsx
@@ -292,6 +292,8 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
     const renderActor = (a: Actor, isBg: boolean) => {
         const t = Math.round(currentFrame * frameMs);
         const pose = sample(a, t);
+        const baseEmojiSize = size.w / 10;
+        const baseTextSize = size.w / 15;
 
         if (a.type === 'composite') {
             const comp = a as CompositeActor;
@@ -312,7 +314,9 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
             }
 
             const dominant = Math.max(...comp.parts.map((p) => p.start?.scale ?? 1));
-            const unitSize = comp.meta?.sizeOverride ?? Math.round((48 * (a.start?.scale ?? 1)) / dominant);
+            const unitSize =
+                comp.meta?.sizeOverride ??
+                Math.round((baseEmojiSize * (a.start?.scale ?? 1)) / dominant);
             const widthPx = (maxX - minX) * unitSize;
             const heightPx = (maxY - minY) * unitSize;
 
@@ -390,10 +394,10 @@ export default function SceneCanvas({ scene, fps, width, height, onSceneChange, 
         }
 
         const baseFontSize = a.type === 'emoji'
-            ? Math.round(48 * (a.start?.scale ?? 1))
+            ? Math.round(baseEmojiSize * (a.start?.scale ?? 1))
             : a.type === 'text' && (a as any).fontSize
                 ? (a as any).fontSize
-                : Math.round(32 * (a.start?.scale ?? 1));
+                : Math.round(baseTextSize * (a.start?.scale ?? 1));
 
         const style: React.CSSProperties = {
             left: pose.x * 100 + '%',


### PR DESCRIPTION
## Summary
- derive base emoji/text sizes from player width for consistent scaling
- apply width-based sizing in editor canvas and composite actor handling
- update thumbnail and OG image generation to use proportional units

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bae5f04d9483269f64461fd76a75f5