### PR TITLE
Implement channel follow system and feed

### DIFF
--- a/Supabase.sql
+++ b/Supabase.sql
@@ -186,3 +186,22 @@ create policy "Profiles are viewable by everyone" on public.profiles
 create policy "Users can update their own profile" on public.profiles
   for update using (auth.uid() = user_id);
 
+-- Follows table for user follows
+create table if not exists public.follows (
+  follower_id uuid references auth.users(id),
+  channel_id uuid references public.channels(id),
+  created_at timestamptz default now(),
+  primary key (follower_id, channel_id)
+);
+
+alter table public.follows enable row level security;
+
+create policy "Public read access" on public.follows
+  for select using (true);
+
+create policy "Users can insert their own follows" on public.follows
+  for insert with check (auth.uid() = follower_id);
+
+create policy "Users can delete their own follows" on public.follows
+  for delete using (auth.uid() = follower_id);
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,12 +9,14 @@ import {
   getAllMovies,
   getTrendingMovies,
   getRecommendedMovies,
+  getFollowingMovies,
 } from '../lib/supabaseClient';
 
 export default function Page() {
   const [movies, setMovies] = useState<any[]>([]);
   const [trending, setTrending] = useState<any[]>([]);
   const [recommended, setRecommended] = useState<any[]>([]);
+  const [following, setFollowing] = useState<any[]>([]);
   const [extrasLoaded, setExtrasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pageRef = useRef(0);
@@ -53,12 +55,14 @@ export default function Page() {
   useEffect(() => {
     const fetchExtras = async () => {
       try {
-        const [trend, rec] = await Promise.all([
+        const [trend, rec, fol] = await Promise.all([
           getTrendingMovies(),
           getRecommendedMovies(),
+          getFollowingMovies(),
         ]);
         setTrending(trend);
         setRecommended(rec);
+        setFollowing(fol);
       } catch {
         // ignore
       } finally {
@@ -143,65 +147,89 @@ export default function Page() {
           </div>
         )}
 
-        
-<div className="mt-12">
-  <h2 className="text-2xl font-bold mb-4 text-center">Trending</h2>
-  {trending.length > 0 ? (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-      {trending.map((m) => (
-        <div
-          key={m.id}
-          onClick={(e) => {
-            const target = e.target as HTMLElement;
-            if (!target.closest('a,button')) {
-              router.push(`/movies/${m.id}`);
-            }
-          }}
-          className="cursor-pointer"
-        >
-          <MovieCard movie={m} />
+        <div className="mt-12">
+          <h2 className="text-2xl font-bold mb-4 text-center">Following</h2>
+          {following.length > 0 ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+              {following.map((m) => (
+                <div
+                  key={m.id}
+                  onClick={(e) => {
+                    const target = e.target as HTMLElement;
+                    if (!target.closest('a,button')) {
+                      router.push(`/movies/${m.id}`);
+                    }
+                  }}
+                  className="cursor-pointer"
+                >
+                  <MovieCard movie={m} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            extrasLoaded && (
+              <p className="text-center text-gray-600">
+                Follow channels to see their movies.
+              </p>
+            )
+          )}
         </div>
-      ))}
-    </div>
-  ) : (
-    extrasLoaded && (
-      <p className="text-center text-gray-600">
-        No trending movies yet.
-      </p>
-    )
-  )}
-</div>
 
-
-        
-<div className="mt-12">
-  <h2 className="text-2xl font-bold mb-4 text-center">Recommended for You</h2>
-  {recommended.length > 0 ? (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-      {recommended.map((m) => (
-        <div
-          key={m.id}
-          onClick={(e) => {
-            const target = e.target as HTMLElement;
-            if (!target.closest('a,button')) {
-              router.push(`/movies/${m.id}`);
-            }
-          }}
-          className="cursor-pointer"
-        >
-          <MovieCard movie={m} />
+        <div className="mt-12">
+          <h2 className="text-2xl font-bold mb-4 text-center">Trending</h2>
+          {trending.length > 0 ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+              {trending.map((m) => (
+                <div
+                  key={m.id}
+                  onClick={(e) => {
+                    const target = e.target as HTMLElement;
+                    if (!target.closest('a,button')) {
+                      router.push(`/movies/${m.id}`);
+                    }
+                  }}
+                  className="cursor-pointer"
+                >
+                  <MovieCard movie={m} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            extrasLoaded && (
+              <p className="text-center text-gray-600">
+                No trending movies yet.
+              </p>
+            )
+          )}
         </div>
-      ))}
-    </div>
-  ) : (
-    extrasLoaded && (
-      <p className="text-center text-gray-600">
-        Sign in or like movies to see recommendations.
-      </p>
-    )
-  )}
-</div>
 
+        <div className="mt-12">
+          <h2 className="text-2xl font-bold mb-4 text-center">Recommended for You</h2>
+          {recommended.length > 0 ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+              {recommended.map((m) => (
+                <div
+                  key={m.id}
+                  onClick={(e) => {
+                    const target = e.target as HTMLElement;
+                    if (!target.closest('a,button')) {
+                      router.push(`/movies/${m.id}`);
+                    }
+                  }}
+                  className="cursor-pointer"
+                >
+                  <MovieCard movie={m} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            extrasLoaded && (
+              <p className="text-center text-gray-600">
+                Sign in or like movies to see recommendations.
+              </p>
+            )
+          )}
+        </div>
 
         {/* Call to Action */}
         <div className="flex justify-center mt-12 mb-6">

--- a/lib/supabaseClient.test.ts
+++ b/lib/supabaseClient.test.ts
@@ -108,12 +108,12 @@ test('getChannelFollowers returns follower profiles', async () => {
         return {
           select: () => ({
             in: async (col: string, ids: any[]) => {
-              assert.equal(col, 'id');
+              assert.equal(col, 'user_id');
               assert.deepEqual(ids, ['u1', 'u2']);
               return {
                 data: [
-                  { id: 'u1', display_name: 'A' },
-                  { id: 'u2', display_name: 'B' },
+                  { user_id: 'u1', display_name: 'A' },
+                  { user_id: 'u2', display_name: 'B' },
                 ],
                 error: null,
               };
@@ -126,7 +126,7 @@ test('getChannelFollowers returns follower profiles', async () => {
   } as any;
   const result = await getChannelFollowers('c1', { client: mockClient });
   assert.deepEqual(result, [
-    { id: 'u1', display_name: 'A' },
-    { id: 'u2', display_name: 'B' },
+    { id: 'u1', display_name: 'A', avatar_url: undefined },
+    { id: 'u2', display_name: 'B', avatar_url: undefined },
   ]);
 });

--- a/lib/supabaseClient.test.ts
+++ b/lib/supabaseClient.test.ts
@@ -113,7 +113,6 @@ test('getChannelFollowers returns follower profiles', async () => {
               return {
                 data: [
                   { user_id: 'u1', display_name: 'A' },
-                  { user_id: 'u2', display_name: 'B' },
                 ],
                 error: null,
               };
@@ -127,6 +126,6 @@ test('getChannelFollowers returns follower profiles', async () => {
   const result = await getChannelFollowers('c1', { client: mockClient });
   assert.deepEqual(result, [
     { id: 'u1', display_name: 'A', avatar_url: undefined },
-    { id: 'u2', display_name: 'B', avatar_url: undefined },
+    { id: 'u2', display_name: undefined, avatar_url: undefined },
   ]);
 });

--- a/lib/supabaseClient.test.ts
+++ b/lib/supabaseClient.test.ts
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { followChannel, unfollowChannel, getFollowingMovies } = require('./supabaseClient');
+
+test('followChannel inserts follow record', async () => {
+  const inserted: any[] = [];
+  const mockClient = {
+    from: (table: string) => {
+      assert.equal(table, 'follows');
+      return {
+        insert: async (obj: any) => {
+          inserted.push(obj);
+          return { error: null };
+        },
+      };
+    },
+  } as any;
+  const mockGetUser = async () => ({ id: 'u1' } as any);
+  await followChannel('c1', { client: mockClient, getUserFn: mockGetUser });
+  assert.deepEqual(inserted[0], { follower_id: 'u1', channel_id: 'c1' });
+});
+
+test('unfollowChannel deletes follow record', async () => {
+  let matched: any = null;
+  const mockClient = {
+    from: (table: string) => {
+      assert.equal(table, 'follows');
+      return {
+        delete: () => ({
+          match: async (obj: any) => {
+            matched = obj;
+            return { error: null };
+          },
+        }),
+      };
+    },
+  } as any;
+  const mockGetUser = async () => ({ id: 'u1' } as any);
+  await unfollowChannel('c1', { client: mockClient, getUserFn: mockGetUser });
+  assert.deepEqual(matched, { follower_id: 'u1', channel_id: 'c1' });
+});
+
+test('getFollowingMovies returns movies from followed channels', async () => {
+  const mockMovies = [{ id: 'm1', animation: null }, { id: 'm2', animation: null }];
+  const mockClient = {
+    from: (table: string) => {
+      if (table === 'follows') {
+        return {
+          select: () => ({
+            eq: async () => ({ data: [{ channel_id: 'c1' }], error: null }),
+          }),
+        };
+      }
+      if (table === 'movies') {
+        return {
+          select: () => ({
+            in: (col: string, vals: any[]) => {
+              assert.equal(col, 'channel_id');
+              assert.deepEqual(vals, ['c1']);
+              return {
+                not: () => ({
+                  lte: () => ({
+                    order: async () => ({ data: mockMovies, error: null }),
+                  }),
+                }),
+              };
+            },
+          }),
+        };
+      }
+      throw new Error('unexpected table');
+    },
+  } as any;
+  const mockGetUser = async () => ({ id: 'u1' } as any);
+  const result = await getFollowingMovies({ client: mockClient, getUserFn: mockGetUser });
+  assert.deepEqual(result, mockMovies);
+});

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -505,10 +505,14 @@ export async function getChannelFollowers(
   if (ids.length === 0) return [];
   const { data: profiles, error: profileError } = await client
     .from('profiles')
-    .select('id, display_name, avatar_url')
-    .in('id', ids);
+    .select('user_id, display_name, avatar_url')
+    .in('user_id', ids);
   if (profileError) throw profileError;
-  return profiles || [];
+  return (profiles || []).map((p: any) => ({
+    id: p.user_id,
+    display_name: p.display_name,
+    avatar_url: p.avatar_url,
+  }));
 }
 
 export async function getFollowingMovies(

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -491,6 +491,26 @@ export async function unfollowChannel(
   if (error) throw error;
 }
 
+export async function getChannelFollowers(
+  channelId: string,
+  deps: { client?: typeof supabase } = {},
+) {
+  const { client = supabase } = deps;
+  const { data: follows, error: followError } = await client
+    .from('follows')
+    .select('follower_id')
+    .eq('channel_id', channelId);
+  if (followError) throw followError;
+  const ids = (follows || []).map((f: any) => f.follower_id);
+  if (ids.length === 0) return [];
+  const { data: profiles, error: profileError } = await client
+    .from('profiles')
+    .select('id, display_name, avatar_url')
+    .in('id', ids);
+  if (profileError) throw profileError;
+  return profiles || [];
+}
+
 export async function getFollowingMovies(
   deps: { client?: typeof supabase; getUserFn?: typeof getUser } = {},
 ) {

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -508,11 +508,15 @@ export async function getChannelFollowers(
     .select('user_id, display_name, avatar_url')
     .in('user_id', ids);
   if (profileError) throw profileError;
-  return (profiles || []).map((p: any) => ({
-    id: p.user_id,
-    display_name: p.display_name,
-    avatar_url: p.avatar_url,
-  }));
+  const profileMap = new Map((profiles || []).map((p: any) => [p.user_id, p]));
+  return ids.map((id: string) => {
+    const profile = profileMap.get(id) || {};
+    return {
+      id,
+      display_name: profile.display_name,
+      avatar_url: profile.avatar_url,
+    };
+  });
 }
 
 export async function getFollowingMovies(


### PR DESCRIPTION
## Summary
- allow users to follow channels instead of other users
- show follow/unfollow controls on channel pages and surface followed channel movies on home page
- update unit tests for channel follow logic

## Testing
- `./node_modules/.bin/tsc lib/supabaseClient.test.ts lib/supabaseClient.ts --module commonjs --target ES2022 --outDir lib/test-dist --esModuleInterop`
- `node lib/test-dist/supabaseClient.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc54494ac483268ccf2dcf3d2b955f