### PR TITLE
Enable profile and channel image uploads via Supabase storage

### DIFF
--- a/Supabase.sql
+++ b/Supabase.sql
@@ -165,6 +165,11 @@ insert into storage.buckets (id, name, public)
   values ('channel-pictures', 'channel-pictures', true)
   on conflict (id) do nothing;
 
+-- Storage bucket for profile pictures
+insert into storage.buckets (id, name, public)
+  values ('profile-pictures', 'profile-pictures', true)
+  on conflict (id) do nothing;
+
 -- Profiles table for user accounts
 create table if not exists public.profiles (
   id uuid primary key default gen_random_uuid(),

--- a/app/mychannel/page.tsx
+++ b/app/mychannel/page.tsx
@@ -98,7 +98,13 @@ export default function ChannelPage() {
                                     <input
                                         type="file"
                                         accept="image/*"
-                                        onChange={(e) => setPicture(e.target.files?.[0] || null)}
+                                        onChange={(e) => {
+                                            const file = e.target.files?.[0] || null;
+                                            setPicture(file);
+                                            if (file) {
+                                                setPictureUrl(URL.createObjectURL(file));
+                                            }
+                                        }}
                                         className="hidden"
                                     />
                                 </label>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -7,7 +7,8 @@ import { getProfile, updateProfile } from '../../lib/supabaseClient';
 
 export default function ProfilePage() {
   const [displayName, setDisplayName] = useState('');
-  const [avatarUrl, setAvatarUrl] = useState('');
+  const [avatar, setAvatar] = useState<File | null>(null);
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -17,7 +18,7 @@ export default function ProfilePage() {
       .then((profile) => {
         if (profile) {
           setDisplayName(profile.display_name || '');
-          setAvatarUrl(profile.avatar_url || '');
+          setAvatarUrl(profile.avatar_url || null);
         }
       })
       .catch((e) => setError(e.message));
@@ -29,7 +30,8 @@ export default function ProfilePage() {
     try {
       setError(null);
       setMessage(null);
-      await updateProfile({ display_name: displayName, avatar_url: avatarUrl });
+      const data = await updateProfile({ display_name: displayName, avatar: avatar || undefined });
+      if (data.avatar_url) setAvatarUrl(data.avatar_url);
       setMessage('Profile saved successfully');
     } catch (e: any) {
       setError(e.message);
@@ -74,7 +76,7 @@ export default function ProfilePage() {
               </div>
             )}
 
-            {/* Avatar Preview */}
+            {/* Avatar Upload */}
             <div className="text-center">
               <div className="relative inline-block">
                 {avatarUrl ? (
@@ -90,22 +92,23 @@ export default function ProfilePage() {
                     <CameraIcon size={24} className="text-gray-500" />
                   </div>
                 )}
+                <label className="absolute -bottom-2 -right-2 w-8 h-8 bg-orange-400 hover:bg-orange-500 rounded-full flex items-center justify-center cursor-pointer shadow-lg transition-colors duration-200">
+                  <CameraIcon size={16} className="text-white" />
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0] || null;
+                      setAvatar(file);
+                      if (file) {
+                        setAvatarUrl(URL.createObjectURL(file));
+                      }
+                    }}
+                    className="hidden"
+                  />
+                </label>
               </div>
-            </div>
-
-            {/* Avatar URL */}
-            <div>
-              <label className="flex items-center gap-2 text-sm font-semibold text-gray-700 mb-3">
-                <CameraIcon size={16} />
-                Avatar URL
-              </label>
-              <input
-                type="url"
-                value={avatarUrl}
-                onChange={(e) => setAvatarUrl(e.target.value)}
-                placeholder="https://example.com/avatar.png"
-                className="w-full px-4 py-3 border border-gray-200 rounded-xl focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200 bg-gray-50 hover:bg-white focus:bg-white"
-              />
+              <p className="text-sm text-gray-500 mt-3">Click the camera icon to upload an avatar</p>
             </div>
 
             {/* Display Name */}

--- a/lib/supabaseClient.test.ts
+++ b/lib/supabaseClient.test.ts
@@ -2,13 +2,12 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const {
+import {
   followChannel,
   unfollowChannel,
   getFollowingMovies,
   getChannelFollowers,
-} = require('./supabaseClient');
+} from './supabaseClient';
 
 test('followChannel inserts follow record', async () => {
   const inserted: any[] = [];

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -88,7 +88,10 @@ export async function updateProfile(params: { display_name?: string; avatar?: Fi
     const filePath = `${user.id}_picture.${fileExt}`;
     const { error: uploadError } = await supabase.storage
       .from('profile-pictures')
-      .upload(filePath, params.avatar, { upsert: true });
+      .upload(filePath, params.avatar, {
+        upsert: true,
+        contentType: params.avatar.type,
+      });
     if (uploadError) throw uploadError;
     const { data } = supabase.storage.from('profile-pictures').getPublicUrl(filePath);
     avatar_url = data.publicUrl;
@@ -597,7 +600,10 @@ export async function upsertChannel(params: { name: string; description: string;
     const filePath = `${channel.id}_picture.${fileExt}`;
     const { error: uploadError } = await supabase.storage
       .from('channel-pictures')
-      .upload(filePath, params.picture, { upsert: true });
+      .upload(filePath, params.picture, {
+        upsert: true,
+        contentType: params.picture.type,
+      });
     if (uploadError) throw uploadError;
     const { data } = supabase.storage.from('channel-pictures').getPublicUrl(filePath);
     const { data: updateData, error: updateError } = await supabase

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,19 @@
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseHostname = supabaseUrl ? new URL(supabaseUrl).hostname : undefined;
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: supabaseHostname
+      ? [
+          {
+            protocol: 'https',
+            hostname: supabaseHostname,
+            pathname: '/storage/v1/object/public/**',
+          },
+        ]
+      : [],
+  },
+};
+
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- allow users to upload avatars from profile settings with previews
- store profile and channel images in Supabase storage using deterministic filenames
- add storage bucket for profile pictures

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test`
- `npm run lint`
- `npm run build` *(fails: Failed to collect page data for /api/storyboard)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaff0b4b483268e4d2e6dcabbc311