### PR TITLE
refactor: export layout metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,19 +1,23 @@
 import type { ReactNode } from 'react';
-import Head from 'next/head';
 import '../tailwind/output.css';
 import { Navbar } from '../components/Navbar';
+
+export const metadata = {
+  title: 'Emojiclips.com - Tell your story with emojis',
+  description: 'Turn stories into emoji mini-movies',
+  openGraph: {
+    title: 'Emoji Movie MVP',
+    description: 'Turn stories into emoji mini-movies',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+  },
+};
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <Head>
-        <title>Emojiclips.com - Tell your story with emojis</title>
-        <meta name="description" content="Turn stories into emoji mini-movies" />
-        <meta property="og:title" content="Emoji Movie MVP" />
-        <meta property="og:description" content="Turn stories into emoji mini-movies" />
-        <meta property="og:type" content="website" />
-        <meta name="twitter:card" content="summary_large_image" />
-      </Head>
       <body className="min-h-screen bg-gray-50 text-gray-900">
         <Navbar />
         {children}


### PR DESCRIPTION
## Summary
- move RootLayout SEO tags to exported `metadata`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdfbb2219483268d432ffda44d0107