### PR TITLE
test: expand SEO checklist

### DIFF
--- a/scripts/seo-checklist.js
+++ b/scripts/seo-checklist.js
@@ -16,6 +16,15 @@ function fetchHtml(path) {
   });
 }
 
+function fetchStatus(path) {
+  return new Promise((resolve, reject) => {
+    http.get({ host: 'localhost', port: 3000, path }, res => {
+      res.resume();
+      res.on('end', () => resolve(res.statusCode));
+    }).on('error', reject);
+  });
+}
+
 (async () => {
   const server = spawn('npx', ['next', 'dev', '-p', '3000'], { stdio: 'inherit' });
   await wait(5000);
@@ -26,11 +35,40 @@ function fetchHtml(path) {
     if (!rootHtml.includes('<title>')) {
       throw new Error('Root page missing title');
     }
+    if (!rootHtml.includes('meta name="description"')) {
+      throw new Error('Root page missing meta description');
+    }
     if (!clipHtml.includes('og:image')) {
       throw new Error('Clip page missing og:image');
     }
     if (!clipHtml.includes('thumbnail')) {
       throw new Error('Clip page missing thumbnail meta');
+    }
+    if (!clipHtml.includes('meta name="description"')) {
+      throw new Error('Clip page missing meta description');
+    }
+    if (!rootHtml.includes('rel="canonical"')) {
+      throw new Error('Root page missing canonical link');
+    }
+    if (!clipHtml.includes('rel="canonical"')) {
+      throw new Error('Clip page missing canonical link');
+    }
+    if (!rootHtml.includes('meta name="robots"')) {
+      throw new Error('Root page missing robots meta');
+    }
+    if (!clipHtml.includes('meta name="robots"')) {
+      throw new Error('Clip page missing robots meta');
+    }
+    const robotsStatus = await fetchStatus('/robots.txt');
+    if (robotsStatus !== 200) {
+      throw new Error('robots.txt missing');
+    }
+    const sitemapStatus = await fetchStatus('/sitemap.xml');
+    if (sitemapStatus !== 200) {
+      throw new Error('sitemap.xml missing');
+    }
+    if (!clipHtml.includes('application/ld+json')) {
+      throw new Error('Clip page missing JSON-LD');
     }
 
     console.log('SEO checks passed');


### PR DESCRIPTION
## Summary
- extend SEO script to check meta description, canonical link, robots meta, robots.txt, sitemap.xml, and JSON-LD on clip pages

## Testing
- `node scripts/seo-checklist.js` *(fails: Root page missing canonical link)*

------
https://chatgpt.com/codex/tasks/task_e_68be0a8faa9883269839c38bed8c5a27