### PR TITLE
feat: add video rendering endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Use Node.js LTS image with Debian for glibc compatibility
+FROM node:20-bullseye
+
+# Install ffmpeg so fluent-ffmpeg can execute it
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json* ./
+RUN npm install --production || true
+
+# Copy application including fonts
+COPY . .
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ Open http://localhost:3000 and click **Generate with AI**.
 - Emoji actors and backgrounds can use any Unicode emoji. The `lib/assets` module
   contains example emoji with suggested default scales, but the model is free to
   infer real-world size relationships when new emoji are used.
+
+## Video Endpoint
+Clients can request a rendered MP4 for any clip by calling:
+
+```
+GET /api/video/<clipId>
+```
+
+The server generates each frame on the fly using the clip's animation data and streams
+an H.264 MP4 response. The result can be downloaded or played directly by the client.

--- a/app/api/video/[clipId]/route.ts
+++ b/app/api/video/[clipId]/route.ts
@@ -1,0 +1,138 @@
+import { PassThrough } from 'stream';
+import path from 'path';
+import fs from 'fs';
+import ffmpeg from 'fluent-ffmpeg';
+import ffmpegPath from 'ffmpeg-static';
+import { createCanvas, GlobalFonts } from '@napi-rs/canvas';
+import { getClip } from '../../../../lib/supabaseServer';
+import type { Scene, Actor, EmojiActor, CompositeActor } from '../../../../components/AnimationTypes';
+
+export const runtime = 'nodejs';
+
+function lerp(a: number, b: number, t: number) {
+  return a + (b - a) * t;
+}
+
+function interpolateKeyframes(kfs: any[], t: number) {
+  if (kfs.length === 0) return { x: 0.5, y: 0.5, scale: 1 };
+  let prev = kfs[0];
+  let next = kfs[kfs.length - 1];
+  for (let i = 1; i < kfs.length; i++) {
+    if (t <= kfs[i].t) {
+      next = kfs[i];
+      prev = kfs[i - 1];
+      break;
+    }
+  }
+  const span = next.t - prev.t || 1;
+  const p = (t - prev.t) / span;
+  return {
+    x: lerp(prev.x, next.x, p),
+    y: lerp(prev.y, next.y, p),
+    scale: lerp(prev.scale ?? 1, next.scale ?? 1, p),
+  };
+}
+
+function drawEmoji(ctx: any, actor: EmojiActor, t: number, width: number, height: number, baseUnit: number, font: string) {
+  const state = interpolateKeyframes(actor.tracks, t);
+  const size = baseUnit * (state.scale ?? 1);
+  const x = state.x * width;
+  const y = state.y * height;
+  ctx.save();
+  ctx.font = `${size}px "${font}"`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  if (actor.flipX) {
+    ctx.translate(x, y);
+    ctx.scale(-1, 1);
+    ctx.fillText(actor.emoji, 0, 0);
+  } else {
+    ctx.fillText(actor.emoji, x, y);
+  }
+  ctx.restore();
+}
+
+function drawComposite(ctx: any, actor: CompositeActor, t: number, width: number, height: number, baseUnit: number, font: string) {
+  const state = interpolateKeyframes(actor.tracks, t);
+  const unit = baseUnit * (state.scale ?? 1);
+  const x = state.x * width;
+  const y = state.y * height;
+  ctx.save();
+  ctx.translate(x, y);
+  if (actor.flipX) ctx.scale(-1, 1);
+  for (const part of actor.parts) {
+    const ps = part.start?.scale ?? 1;
+    const px = (part.start?.x ?? 0) * unit;
+    const py = (part.start?.y ?? 0) * unit;
+    ctx.font = `${unit * ps}px "${font}"`;
+    ctx.fillText(part.emoji, px, py);
+  }
+  ctx.restore();
+}
+
+function drawActor(ctx: any, actor: Actor, t: number, width: number, height: number, baseUnit: number, font: string) {
+  if (actor.type === 'emoji') return drawEmoji(ctx, actor as EmojiActor, t, width, height, baseUnit, font);
+  if (actor.type === 'composite') return drawComposite(ctx, actor as CompositeActor, t, width, height, baseUnit, font);
+}
+
+export async function GET(_req: Request, { params }: { params: { clipId: string } }) {
+  const { clipId } = params;
+  const clip = await getClip(clipId);
+  const animation = clip?.animation as { scenes: Scene[]; fps?: number; emojiFont?: string } | undefined;
+  const fps = animation?.fps ?? 30;
+  const emojiFont = animation?.emojiFont || clip?.emoji_font || 'Noto Emoji';
+
+  // Register fonts
+  const fontDir = path.join(process.cwd(), 'public', 'fonts');
+  for (const file of fs.readdirSync(fontDir)) {
+    const full = path.join(fontDir, file);
+    try {
+      GlobalFonts.register(full);
+    } catch {}
+  }
+
+  const width = 640;
+  const height = Math.round((width * 9) / 16);
+  const baseUnit = width / 10;
+  const canvas = createCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+
+  const frameStream = new PassThrough();
+  ffmpeg.setFfmpegPath(ffmpegPath as string);
+  const command = ffmpeg()
+    .input(frameStream)
+    .inputFormat('image2pipe')
+    .inputOptions(['-framerate ' + fps])
+    .outputOptions(['-c:v libx264', '-pix_fmt yuv420p'])
+    .format('mp4');
+  const output = new PassThrough();
+  command.pipe(output);
+  command.on('error', (e) => output.destroy(e));
+  command.on('end', () => output.end());
+
+  (async () => {
+    if (animation?.scenes) {
+      for (const scene of animation.scenes) {
+        const frames = Math.round((scene.duration_ms / 1000) * fps);
+        for (let i = 0; i < frames; i++) {
+          const t = (i / fps) * 1000;
+          ctx.fillStyle = scene.backgroundColor || '#fff';
+          ctx.fillRect(0, 0, width, height);
+          for (const a of scene.backgroundActors) drawActor(ctx, a, t, width, height, baseUnit, emojiFont);
+          for (const a of scene.actors) drawActor(ctx, a, t, width, height, baseUnit, emojiFont);
+          const buffer = canvas.toBuffer('image/png');
+          frameStream.write(buffer);
+        }
+      }
+    }
+    frameStream.end();
+    command.run();
+  })();
+
+  return new Response(output as any, {
+    headers: {
+      'Content-Type': 'video/mp4',
+    },
+  });
+}
+

--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
     "generate:tailwind": "tailwindcss -i ./tailwind/main.css -o ./tailwind/output.css"
   },
   "dependencies": {
+    "@napi-rs/canvas": "^0.1.55",
     "@phosphor-icons/react": "^2.1.6",
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "latest",
     "emojibase-data": "latest",
+    "ffmpeg-static": "^5.1.0",
+    "fluent-ffmpeg": "^2.1.2",
     "framer-motion": "11.2.10",
     "next": "14.2.5",
     "openai": "^4.57.0",


### PR DESCRIPTION
## Summary
- document `/api/video/<clipId>` endpoint for streaming MP4 clips
- add video generation route using canvas and ffmpeg
- include ffmpeg and fonts in Docker deployment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beb69e9cbc83269bf6cfce76cdf00e