### PR TITLE
Synchronize actor selection between canvas and editors

### DIFF
--- a/components/ActorEditor.tsx
+++ b/components/ActorEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
     SmileyWinkIcon,
     TextTIcon,
@@ -28,16 +28,26 @@ export type ActorEditorProps = {
     onRemove: () => void;
     allowTypeChange?: boolean;
     emojiFont?: string;
+    isSelected?: boolean;
+    onSelect?: () => void;
 };
 
-export default function ActorEditor({ actor, onChange, onRemove, allowTypeChange = true, emojiFont }: ActorEditorProps) {
+export default function ActorEditor({ actor, onChange, onRemove, allowTypeChange = true, emojiFont, isSelected = false, onSelect }: ActorEditorProps) {
     const [isExpanded, setIsExpanded] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
     const [showEmojiCatalogue, setShowEmojiCatalogue] = useState(false);
     const [partCatalogueIndex, setPartCatalogueIndex] = useState<number | null>(null);
     const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
     const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
     const emojiStyle = emojiFont ? { fontFamily: emojiFont } : undefined;
+
+    useEffect(() => {
+        if (isSelected) {
+            setIsExpanded(true);
+            containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+    }, [isSelected]);
 
     const update = (fields: any) => onChange({ ...actor, ...fields });
 
@@ -305,12 +315,18 @@ export default function ActorEditor({ actor, onChange, onRemove, allowTypeChange
 
     return (
         <>
-            <div className="border border-gray-200 rounded-lg shadow-sm bg-white overflow-hidden">
+            <div
+                ref={containerRef}
+                className={`border border-gray-200 rounded-lg shadow-sm bg-white overflow-hidden ${isSelected ? 'ring-2 ring-orange-300' : ''}`}
+            >
                 {/* Actor Header */}
                 <div className="flex items-center justify-between p-4 hover:bg-gray-50 transition-colors">
                     <button
                         className="flex items-center gap-3 flex-1 text-left"
-                        onClick={() => setIsExpanded(!isExpanded)}
+                        onClick={() => {
+                            onSelect?.();
+                            setIsExpanded(!isExpanded);
+                        }}
                     >
                         <div className="flex items-center gap-2">
                             {getActorIcon()}

--- a/components/SceneCanvasActorInfo.tsx
+++ b/components/SceneCanvasActorInfo.tsx
@@ -21,7 +21,7 @@ export default function SceneCanvasActorInfo({ actor, currentFrame, frameMs, sam
                     <div className="w-6 h-6 bg-blue-100 rounded-full flex items-center justify-center">
                         <UserIcon size={12} className="text-blue-600" />
                     </div>
-                    <span className="font-medium text-blue-900">Selected: {actor.type}</span>
+                    <span className="font-medium text-blue-900">Selected: {actor.type} ({actor.id})</span>
                 </div>
                 <div className="text-sm text-blue-700">
                     Frame {currentFrame} ({Math.round(currentFrame * frameMs)}ms)

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -41,6 +41,7 @@ export type SceneEditorProps = {
 
 export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicate, sceneIndex, emojiFont, aspectRatio }: SceneEditorProps) {
     const [activeSection, setActiveSection] = useState<'actors' | 'background'>('actors');
+    const [selectedActorId, setSelectedActorId] = useState<string | null>(null);
 
     const { width: CANVAS_WIDTH, height: CANVAS_HEIGHT } = getCanvasDimensions(aspectRatio);
 
@@ -210,6 +211,8 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
                         aspectRatio={aspectRatio}
                         onSceneChange={onChange}
                         emojiFont={emojiFont}
+                        selectedActorId={selectedActorId}
+                        onSelect={setSelectedActorId}
                     />
                 </div>
                 <div className="w-full">
@@ -271,6 +274,8 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
                                         onRemove={() => removeBackground(i)}
                                         allowTypeChange={false}
                                         emojiFont={emojiFont}
+                                        isSelected={a.id === selectedActorId}
+                                        onSelect={() => setSelectedActorId(a.id)}
                                     />
                                 ))}
                                 {scene.backgroundActors.length === 0 && (
@@ -324,6 +329,8 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
                                         onChange={(ac) => updateActor(i, ac)}
                                         onRemove={() => removeActor(i)}
                                         emojiFont={emojiFont}
+                                        isSelected={a.id === selectedActorId}
+                                        onSelect={() => setSelectedActorId(a.id)}
                                     />
                                 ))}
                                 {scene.actors.length === 0 && (


### PR DESCRIPTION
## Summary
- Expose `selectedActorId` and `onSelect` in `SceneCanvas` and trigger callbacks when actors are interacted with
- Track selected actor in `SceneEditor` and highlight matching `ActorEditor`
- Auto-expand and scroll to the selected `ActorEditor`, and show selected actor details in info panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c096b78a5883269993b5b7c389e51e