### PR TITLE
feat: configure caption font size

### DIFF
--- a/components/AnimationTypes.ts
+++ b/components/AnimationTypes.ts
@@ -60,6 +60,8 @@ export type Scene = {
   duration_ms: number; // scene duration
   backgroundActors: EmojiActor[]; // actors rendered behind foreground
   caption?: string;
+  /** Optional font size for the caption in pixels */
+  captionFontSize?: number;
   /** Optional solid background color for the scene */
   backgroundColor?: string;
   actors: Actor[];

--- a/components/EmojiPlayer.tsx
+++ b/components/EmojiPlayer.tsx
@@ -403,7 +403,10 @@ function SceneView({
           />
         ))}
       {scene.caption && (
-        <div className="absolute bottom-4 left-0 right-0 text-center text-white font-medium text-lg px-4">
+        <div
+          className="absolute bottom-4 left-0 right-0 text-center text-white font-medium text-lg px-4"
+          style={{ fontSize: scene.captionFontSize }}
+        >
           <div className="inline-block bg-black/40 backdrop-blur-sm px-3 py-1 rounded-lg">
             {scene.caption}
           </div>

--- a/components/EmojiPlayer.tsx
+++ b/components/EmojiPlayer.tsx
@@ -357,7 +357,7 @@ export const EmojiPlayer = forwardRef(function EmojiPlayer(
   );
 });
 
-function SceneView({
+export function SceneView({
   scene,
   width,
   height,
@@ -404,10 +404,16 @@ function SceneView({
         ))}
       {scene.caption && (
         <div
-          className="absolute bottom-4 left-0 right-0 text-center text-white font-medium text-lg px-4"
-          style={{ fontSize: scene.captionFontSize }}
+          className="absolute left-0 right-0 text-center text-white font-medium text-lg"
+          style={{
+            fontSize: scene.captionFontSize,
+            bottom: '1em',
+          }}
         >
-          <div className="inline-block bg-black/40 backdrop-blur-sm px-3 py-1 rounded-lg">
+          <div
+            className="inline-block bg-black/40 backdrop-blur-sm rounded-lg"
+            style={{ padding: '0.25em 0.75em' }}
+          >
             {scene.caption}
           </div>
         </div>

--- a/components/SceneCanvas.tsx
+++ b/components/SceneCanvas.tsx
@@ -501,6 +501,24 @@ export default function SceneCanvas({ scene, fps, width, height, aspectRatio, on
                 {/* Foreground Actors */}
                 {scene.actors.map((a) => renderActor(a, false))}
 
+                {/* Caption Preview */}
+                {scene.caption && (
+                    <div
+                        className="absolute left-0 right-0 text-center text-white font-medium text-lg pointer-events-none"
+                        style={{
+                            fontSize: scene.captionFontSize,
+                            bottom: '1em',
+                        }}
+                    >
+                        <div
+                            className="inline-block bg-black/40 backdrop-blur-sm rounded-lg"
+                            style={{ padding: '0.25em 0.75em' }}
+                        >
+                            {scene.caption}
+                        </div>
+                    </div>
+                )}
+
                 {/* Animation Paths */}
                 {allActors.length > 0 && (
                     <svg

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -179,6 +179,19 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
                     </div>
                     <div>
                         <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+                            <TextTIcon size={14} />
+                            Caption Size
+                        </label>
+                        <input
+                            type="number"
+                            className="border border-gray-300 rounded-md px-3 py-2 w-full focus:ring-2 focus:ring-orange-300 focus:border-transparent"
+                            value={scene.captionFontSize ?? ''}
+                            placeholder="18"
+                            onChange={(e) => update({ captionFontSize: e.target.value ? Number(e.target.value) : undefined })}
+                        />
+                    </div>
+                    <div>
+                        <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
                             <PaletteIcon size={14} />
                             Background
                         </label>

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -25,6 +25,7 @@ import {
 } from './AnimationTypes';
 import ActorEditor from './ActorEditor';
 import SceneCanvas from './SceneCanvas';
+import { SceneView } from './EmojiPlayer';
 import { getCanvasDimensions } from '../lib/aspectRatio';
 import { uuid } from '../lib/uuid';
 
@@ -47,6 +48,7 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
 
     const update = (fields: Partial<Scene>) => onChange({ ...scene, ...fields });
     const defaultBg = emojiFont === 'Noto Emoji' ? '#ffffff' : '#000000';
+    const emojiStyle = emojiFont ? { fontFamily: emojiFont } : undefined;
 
     const updateActor = (idx: number, actor: Actor) => {
         const actors = [...scene.actors];
@@ -215,6 +217,16 @@ export default function SceneEditor({ scene, fps, onChange, onRemove, onDuplicat
 
             {/* Main Content */}
             <div className="flex flex-col gap-6">
+                <div className="flex justify-center">
+                    <SceneView
+                        scene={scene}
+                        width={CANVAS_WIDTH}
+                        height={CANVAS_HEIGHT}
+                        progress={0}
+                        emojiStyle={emojiStyle}
+                        backgroundColor={scene.backgroundColor ?? defaultBg}
+                    />
+                </div>
                 <div className="flex justify-center">
                     <SceneCanvas
                         scene={scene}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -56,6 +56,7 @@ export const sceneSchema = z.object({
   duration_ms: z.number().positive(),
   backgroundActors: z.array(emojiActorSchema).default([]),
   caption: z.string().optional(),
+  captionFontSize: z.number().positive().optional(),
   actors: z.array(actorSchema),
   effects: z.array(effectSchema).optional(),
   sfx: z.array(z.object({ at_ms: z.number().nonnegative(), type: z.enum(['pop','whoosh','ding']) })).optional()


### PR DESCRIPTION
## Summary
- allow scenes to specify a captionFontSize
- add caption size control in scene editor
- render captions with configured size in player

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c098bb4ac48326b4d498d2b7cb835c