### PR TITLE
Add basic informational pages and site footer

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -7,15 +7,37 @@ export const metadata: Metadata = {
 
 export default function AboutPage() {
   return (
-    <main className="max-w-3xl mx-auto p-6 space-y-4">
+    <main className="max-w-3xl mx-auto p-6 space-y-6">
       <h1 className="text-3xl font-bold">About EmojiStory</h1>
       <p>
         EmojiStory is an experimental studio that transforms short stories into playful emoji movies.
         We aim to make storytelling simple, creative, and fun for everyone.
       </p>
       <p>
-        Whether you are sharing a joke, documenting an adventure, or crafting a fantasy,
-        our tools help you express ideas through animated emoji scenes.
+        The project started as a small hackathon idea and has grown into a sandbox for exploring
+        how generative AI and whimsical design can bring tiny narratives to life.
+      </p>
+      <h2 className="text-2xl font-semibold">Our Mission</h2>
+      <p>
+        We believe anyone should be able to share a story without needing expensive software
+        or a background in animation. Our mission is to lower the barrier to creative expression
+        by providing a playful canvas made entirely of emojis.
+      </p>
+      <h2 className="text-2xl font-semibold">How It Works</h2>
+      <p>
+        Using a mix of OpenAI tools and open-source animation libraries, EmojiStory converts your
+        written prompts into short emoji scenes. The system chooses characters, sets backgrounds,
+        and animates emotions to match the script.
+      </p>
+      <ul className="list-disc list-inside">
+        <li>Create a script using simple text prompts.</li>
+        <li>Pick from a library of emoji characters and locations.</li>
+        <li>Share your finished emoji movie with friends or the community.</li>
+      </ul>
+      <h2 className="text-2xl font-semibold">What&apos;s Next</h2>
+      <p>
+        We are continually experimenting with new features such as collaborative story building,
+        sound effects, and export options. Follow along and help shape the future of EmojiStory.
       </p>
     </main>
   );

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,16 +1,16 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'About EmojiStory',
-  description: 'Learn about EmojiStory and how we turn stories into emoji movies.'
+  title: 'About EmojiClips',
+  description: 'Learn about EmojiClips and how we turn stories into emoji movies.'
 };
 
 export default function AboutPage() {
   return (
     <main className="max-w-3xl mx-auto p-6 space-y-6">
-      <h1 className="text-3xl font-bold">About EmojiStory</h1>
+      <h1 className="text-3xl font-bold">About EmojiClips</h1>
       <p>
-        EmojiStory is an experimental studio that transforms short stories into playful emoji movies.
+        EmojiClips is an experimental studio that transforms short stories into playful emoji movies.
         We aim to make storytelling simple, creative, and fun for everyone.
       </p>
       <p>
@@ -25,7 +25,7 @@ export default function AboutPage() {
       </p>
       <h2 className="text-2xl font-semibold">How It Works</h2>
       <p>
-        Using a mix of OpenAI tools and open-source animation libraries, EmojiStory converts your
+        Using a mix of OpenAI tools and open-source animation libraries, EmojiClips converts your
         written prompts into short emoji scenes. The system chooses characters, sets backgrounds,
         and animates emotions to match the script.
       </p>
@@ -37,7 +37,7 @@ export default function AboutPage() {
       <h2 className="text-2xl font-semibold">What&apos;s Next</h2>
       <p>
         We are continually experimenting with new features such as collaborative story building,
-        sound effects, and export options. Follow along and help shape the future of EmojiStory.
+        sound effects, and export options. Follow along and help shape the future of EmojiClips.
       </p>
     </main>
   );

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'About EmojiStory',
+  description: 'Learn about EmojiStory and how we turn stories into emoji movies.'
+};
+
+export default function AboutPage() {
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">About EmojiStory</h1>
+      <p>
+        EmojiStory is an experimental studio that transforms short stories into playful emoji movies.
+        We aim to make storytelling simple, creative, and fun for everyone.
+      </p>
+      <p>
+        Whether you are sharing a joke, documenting an adventure, or crafting a fantasy,
+        our tools help you express ideas through animated emoji scenes.
+      </p>
+    </main>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-  title: 'Contact EmojiStory',
-  description: 'Get in touch with the EmojiStory team.'
+  title: 'Contact EmojiClips',
+  description: 'Get in touch with the EmojiClips team.'
 };
 
 export default function ContactPage() {
@@ -16,8 +16,8 @@ export default function ContactPage() {
       </p>
       <p>
         Send us an email at{' '}
-        <Link href="mailto:hello@emojistory.com" className="text-blue-600 hover:underline">
-          hello@emojistory.com
+        <Link href="mailto:hello@emojiclips.com" className="text-blue-600 hover:underline">
+          hello@emojiclips.com
         </Link>{' '}
         and we will get back to you.
       </p>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -8,14 +8,56 @@ export const metadata: Metadata = {
 
 export default function ContactPage() {
   return (
-    <main className="max-w-3xl mx-auto p-6 space-y-4">
+    <main className="max-w-3xl mx-auto p-6 space-y-6">
       <h1 className="text-3xl font-bold">Contact Us</h1>
       <p>
         Have questions, feedback, or just want to say hello? We would love to hear from you.
+        Every message helps us improve the experience of building movies out of emojis.
       </p>
       <p>
-        Send us an email at <Link href="mailto:hello@emojistory.com" className="text-blue-600 hover:underline">hello@emojistory.com</Link>
+        Send us an email at{' '}
+        <Link href="mailto:hello@emojistory.com" className="text-blue-600 hover:underline">
+          hello@emojistory.com
+        </Link>{' '}
         and we will get back to you.
+      </p>
+      <h2 className="text-2xl font-semibold">Other Ways to Connect</h2>
+      <ul className="list-disc list-inside">
+        <li>
+          Follow our updates on{' '}
+          <Link
+            href="https://twitter.com"
+            className="text-blue-600 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Twitter
+          </Link>
+          .
+        </li>
+        <li>
+          Join the conversation on our{' '}
+          <Link href="#" className="text-blue-600 hover:underline">
+            community forum
+          </Link>{' '}
+          to share ideas and get support.
+        </li>
+        <li>
+          Report bugs or request features on{' '}
+          <Link
+            href="https://github.com"
+            className="text-blue-600 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </Link>
+          .
+        </li>
+      </ul>
+      <p>
+        We aim to respond within two business days. Your patience is appreciated as our tiny team works
+        through messages.
       </p>
     </main>
   );

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Contact EmojiStory',
+  description: 'Get in touch with the EmojiStory team.'
+};
+
+export default function ContactPage() {
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Contact Us</h1>
+      <p>
+        Have questions, feedback, or just want to say hello? We would love to hear from you.
+      </p>
+      <p>
+        Send us an email at <Link href="mailto:hello@emojistory.com" className="text-blue-600 hover:underline">hello@emojistory.com</Link>
+        and we will get back to you.
+      </p>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import '../tailwind/output.css';
 import { Navbar } from '../components/Navbar';
+import { Footer } from '../components/Footer';
 
 export const metadata = {
   title: 'Emojiclips.com - Tell your story with emojis',
@@ -25,6 +26,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <body className="min-h-screen bg-gray-50 text-gray-900">
         <Navbar />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy - EmojiStory',
+  description: 'Read about how EmojiStory respects and protects your privacy.'
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Privacy Policy</h1>
+      <p>
+        We value your privacy and are committed to safeguarding your personal information.
+      </p>
+      <p>
+        EmojiStory only collects the data necessary to provide our service and never sells your information to third parties.
+      </p>
+    </main>
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy - EmojiStory',
@@ -7,13 +8,41 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
-    <main className="max-w-3xl mx-auto p-6 space-y-4">
+    <main className="max-w-3xl mx-auto p-6 space-y-6">
       <h1 className="text-3xl font-bold">Privacy Policy</h1>
       <p>
         We value your privacy and are committed to safeguarding your personal information.
+        This policy outlines what data we collect, how we use it, and the choices you have.
       </p>
+      <h2 className="text-2xl font-semibold">Information We Collect</h2>
       <p>
-        EmojiStory only collects the data necessary to provide our service and never sells your information to third parties.
+        When you create an account or use EmojiStory, we may collect basic information such as your
+        email address and usage statistics. This data helps us maintain your account and improve the
+        service.
+      </p>
+      <h2 className="text-2xl font-semibold">How We Use Information</h2>
+      <p>
+        The information we gather allows us to operate, maintain, and enhance EmojiStory. We do not
+        sell your data to third parties and only share information when necessary to provide the service
+        or comply with legal obligations.
+      </p>
+      <h2 className="text-2xl font-semibold">Cookies and Tracking</h2>
+      <p>
+        We may use cookies to remember your preferences and keep you logged in. You can disable cookies
+        in your browser settings, but some features of EmojiStory may not work properly without them.
+      </p>
+      <h2 className="text-2xl font-semibold">Data Security</h2>
+      <p>
+        We implement industry-standard measures to protect your information. However, no method of
+        transmission or storage is completely secure, so we cannot guarantee absolute security.
+      </p>
+      <h2 className="text-2xl font-semibold">Contact</h2>
+      <p>
+        If you have questions about this policy, email us at{' '}
+        <Link href="mailto:privacy@emojistory.com" className="text-blue-600 hover:underline">
+          privacy@emojistory.com
+        </Link>
+        .
       </p>
     </main>
   );

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-  title: 'Privacy Policy - EmojiStory',
-  description: 'Read about how EmojiStory respects and protects your privacy.'
+  title: 'Privacy Policy - EmojiClips',
+  description: 'Read about how EmojiClips respects and protects your privacy.'
 };
 
 export default function PrivacyPage() {
@@ -16,20 +16,20 @@ export default function PrivacyPage() {
       </p>
       <h2 className="text-2xl font-semibold">Information We Collect</h2>
       <p>
-        When you create an account or use EmojiStory, we may collect basic information such as your
+        When you create an account or use EmojiClips, we may collect basic information such as your
         email address and usage statistics. This data helps us maintain your account and improve the
         service.
       </p>
       <h2 className="text-2xl font-semibold">How We Use Information</h2>
       <p>
-        The information we gather allows us to operate, maintain, and enhance EmojiStory. We do not
+        The information we gather allows us to operate, maintain, and enhance EmojiClips. We do not
         sell your data to third parties and only share information when necessary to provide the service
         or comply with legal obligations.
       </p>
       <h2 className="text-2xl font-semibold">Cookies and Tracking</h2>
       <p>
         We may use cookies to remember your preferences and keep you logged in. You can disable cookies
-        in your browser settings, but some features of EmojiStory may not work properly without them.
+        in your browser settings, but some features of EmojiClips may not work properly without them.
       </p>
       <h2 className="text-2xl font-semibold">Data Security</h2>
       <p>
@@ -39,8 +39,8 @@ export default function PrivacyPage() {
       <h2 className="text-2xl font-semibold">Contact</h2>
       <p>
         If you have questions about this policy, email us at{' '}
-        <Link href="mailto:privacy@emojistory.com" className="text-blue-600 hover:underline">
-          privacy@emojistory.com
+        <Link href="mailto:hello@emojiclips.com" className="text-blue-600 hover:underline">
+          hello@emojiclips.com
         </Link>
         .
       </p>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Terms of Service - EmojiStory',
@@ -7,13 +8,37 @@ export const metadata: Metadata = {
 
 export default function TermsPage() {
   return (
-    <main className="max-w-3xl mx-auto p-6 space-y-4">
+    <main className="max-w-3xl mx-auto p-6 space-y-6">
       <h1 className="text-3xl font-bold">Terms of Service</h1>
       <p>
-        By using EmojiStory, you agree to abide by our terms and policies designed to keep the community safe and enjoyable.
+        By using EmojiStory, you agree to abide by our terms and policies designed to keep the community safe and
+        enjoyable. Please read the rules below carefully.
       </p>
+      <h2 className="text-2xl font-semibold">Your Responsibilities</h2>
       <p>
-        Please make sure you understand these terms before creating or sharing content on our platform.
+        You are responsible for the content you create and share. Please be respectful of others and follow all
+        applicable laws.
+      </p>
+      <ul className="list-disc list-inside">
+        <li>No illegal or harmful content.</li>
+        <li>Respect intellectual property rights and only upload material you have permission to use.</li>
+        <li>Do not attempt to disrupt or abuse the service.</li>
+      </ul>
+      <h2 className="text-2xl font-semibold">Content Ownership</h2>
+      <p>
+        You retain ownership of the stories and emoji movies you create. By posting them on EmojiStory, you grant us a
+        non-exclusive license to host and display your content so that the service functions as intended.
+      </p>
+      <h2 className="text-2xl font-semibold">Changes to These Terms</h2>
+      <p>
+        We may update these terms from time to time. When we do, we will revise the &quot;last updated&quot; date and, if
+        the changes are significant, provide a notice on the site. Continued use of EmojiStory after changes take effect
+        constitutes acceptance of the new terms.
+      </p>
+      <h2 className="text-2xl font-semibold">Contact</h2>
+      <p>
+        If you have any questions about these terms, please email
+        <Link href="mailto:legal@emojistory.com" className="text-blue-600 hover:underline"> legal@emojistory.com</Link>.
       </p>
     </main>
   );

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service - EmojiStory',
+  description: 'Review the rules and guidelines for using EmojiStory.'
+};
+
+export default function TermsPage() {
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Terms of Service</h1>
+      <p>
+        By using EmojiStory, you agree to abide by our terms and policies designed to keep the community safe and enjoyable.
+      </p>
+      <p>
+        Please make sure you understand these terms before creating or sharing content on our platform.
+      </p>
+    </main>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-  title: 'Terms of Service - EmojiStory',
-  description: 'Review the rules and guidelines for using EmojiStory.'
+  title: 'Terms of Service - EmojiClips',
+  description: 'Review the rules and guidelines for using EmojiClips.'
 };
 
 export default function TermsPage() {
@@ -11,7 +11,7 @@ export default function TermsPage() {
     <main className="max-w-3xl mx-auto p-6 space-y-6">
       <h1 className="text-3xl font-bold">Terms of Service</h1>
       <p>
-        By using EmojiStory, you agree to abide by our terms and policies designed to keep the community safe and
+        By using EmojiClips, you agree to abide by our terms and policies designed to keep the community safe and
         enjoyable. Please read the rules below carefully.
       </p>
       <h2 className="text-2xl font-semibold">Your Responsibilities</h2>
@@ -26,19 +26,19 @@ export default function TermsPage() {
       </ul>
       <h2 className="text-2xl font-semibold">Content Ownership</h2>
       <p>
-        You retain ownership of the stories and emoji movies you create. By posting them on EmojiStory, you grant us a
+        You retain ownership of the stories and emoji movies you create. By posting them on EmojiClips, you grant us a
         non-exclusive license to host and display your content so that the service functions as intended.
       </p>
       <h2 className="text-2xl font-semibold">Changes to These Terms</h2>
       <p>
         We may update these terms from time to time. When we do, we will revise the &quot;last updated&quot; date and, if
-        the changes are significant, provide a notice on the site. Continued use of EmojiStory after changes take effect
+        the changes are significant, provide a notice on the site. Continued use of EmojiClips after changes take effect
         constitutes acceptance of the new terms.
       </p>
       <h2 className="text-2xl font-semibold">Contact</h2>
       <p>
         If you have any questions about these terms, please email
-        <Link href="mailto:legal@emojistory.com" className="text-blue-600 hover:underline"> legal@emojistory.com</Link>.
+        <Link href="mailto:hello@emojiclips.com" className="text-blue-600 hover:underline"> hello@emojiclips.com</Link>.
       </p>
     </main>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+export function Footer() {
+  return (
+    <footer className="bg-gray-100 mt-12">
+      <div className="max-w-7xl mx-auto px-4 py-6 flex flex-col sm:flex-row items-center justify-between text-sm text-gray-600">
+        <p className="mb-4 sm:mb-0">&copy; {new Date().getFullYear()} EmojiStory</p>
+        <div className="flex gap-4">
+          <Link href="/about" className="hover:text-gray-900">About</Link>
+          <Link href="/contact" className="hover:text-gray-900">Contact</Link>
+          <Link href="/privacy" className="hover:text-gray-900">Privacy</Link>
+          <Link href="/terms" className="hover:text-gray-900">Terms</Link>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -158,6 +158,18 @@ export function Navbar() {
                             <span>Clips</span>
                         </Link>
                         <Link
+                            href="/about"
+                            className="text-black hover:text-gray-200 transition-colors duration-200 px-3 py-2 rounded-md hover:bg-white/10"
+                        >
+                            About
+                        </Link>
+                        <Link
+                            href="/contact"
+                            className="text-black hover:text-gray-200 transition-colors duration-200 px-3 py-2 rounded-md hover:bg-white/10"
+                        >
+                            Contact
+                        </Link>
+                        <Link
                             href={user ? '/editor' : '/auth/login'}
                             className="flex items-center gap-2 bg-white text-brand-600 hover:bg-gray-100 transition-colors duration-200 px-4 py-2 rounded-md font-medium shadow-sm"
                         >
@@ -275,6 +287,20 @@ export function Navbar() {
                             >
                                 <FilmSlateIcon size={20} weight="fill" />
                                 Clips
+                            </Link>
+                            <Link
+                                href="/about"
+                                onClick={() => setIsMobileMenuOpen(false)}
+                                className="flex items-center text-white hover:bg-white/10 px-3 py-2 rounded-md transition-colors duration-200"
+                            >
+                                About
+                            </Link>
+                            <Link
+                                href="/contact"
+                                onClick={() => setIsMobileMenuOpen(false)}
+                                className="flex items-center text-white hover:bg-white/10 px-3 py-2 rounded-md transition-colors duration-200"
+                            >
+                                Contact
                             </Link>
                             <Link
                                 href={user ? '/editor' : '/auth/login'}


### PR DESCRIPTION
## Summary
- add About, Contact, Privacy Policy, and Terms of Service pages with metadata
- introduce site-wide Footer linking to informational pages
- expose About and Contact links in Navbar and render Footer across layout

## Testing
- `npm run lint` *(fails: command not found: npm)*
- `npm run build` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c122ea20108326a63f1069906441eb