### PR TITLE
Convert movies page to server component

### DIFF
--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { FilmSlateIcon } from '@phosphor-icons/react';
+import { FilmSlateIcon } from '@phosphor-icons/react/dist/ssr';
 import { getAllMovies } from '../../lib/supabaseServer';
 import { MovieCard } from '../../components/MovieCard';
 

--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -1,89 +1,100 @@
-'use client';
-
-import { useEffect, useState, Suspense } from 'react';
 import Link from 'next/link';
 import { FilmSlateIcon } from '@phosphor-icons/react';
-import { getAllMovies } from '../../lib/supabaseClient';
+import { getAllMovies } from '../../lib/supabaseServer';
 import { MovieCard } from '../../components/MovieCard';
 
-function MoviesContent() {
-  const [movies, setMovies] = useState<any[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+const PAGE_SIZE = 24;
 
-  useEffect(() => {
-    getAllMovies()
-      .then(setMovies)
-      .catch(e => setError(e.message))
-      .finally(() => setLoading(false));
-  }, []);
+interface MoviesPageProps {
+  searchParams?: {
+    page?: string;
+  };
+}
 
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100">
-      <div className="max-w-6xl mx-auto px-6 py-8">
-        <div className="text-center mb-8">
-          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 flex items-center justify-center gap-3 mb-2">
-            <div className="p-2 bg-gradient-to-br from-orange-400 to-yellow-400 rounded-xl shadow-lg">
-              <FilmSlateIcon weight="bold" size={36} className="text-white" />
-            </div>
-            Released Movies
-          </h1>
-          <p className="text-gray-600 text-lg">
-            Browse publicly released emoji movies
-          </p>
-        </div>
+export default async function MoviesPage({ searchParams }: MoviesPageProps) {
+  const page = Math.max(1, Number(searchParams?.page) || 1);
+  const from = (page - 1) * PAGE_SIZE;
+  const to = from + PAGE_SIZE;
 
-        {loading && (
-          <div className="flex justify-center items-center py-16">
-            <div className="flex items-center gap-3 text-gray-500">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-              <span className="text-lg">Loading movies...</span>
-            </div>
+  try {
+    // TODO: Add category/tag filters when these fields are available
+    const movies = await getAllMovies({ from, to });
+    const hasMore = movies.length > PAGE_SIZE;
+    const visible = movies.slice(0, PAGE_SIZE);
+
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100">
+        <div className="max-w-6xl mx-auto px-6 py-8">
+          <div className="text-center mb-8">
+            <h1 className="text-4xl md:text-5xl font-bold text-gray-900 flex items-center justify-center gap-3 mb-2">
+              <div className="p-2 bg-gradient-to-br from-orange-400 to-yellow-400 rounded-xl shadow-lg">
+                <FilmSlateIcon weight="bold" size={36} className="text-white" />
+              </div>
+              Released Movies
+            </h1>
+            <p className="text-gray-600 text-lg">Browse publicly released emoji movies</p>
           </div>
-        )}
 
-        {error && (
+          {visible.length === 0 ? (
+            <div className="text-center py-16">
+              <div className="w-24 h-24 mx-auto mb-6 opacity-30">
+                <FilmSlateIcon weight="light" size={96} className="text-gray-400" />
+              </div>
+              <h2 className="text-2xl font-semibold text-gray-700 mb-3">No Movies Yet</h2>
+              <p className="text-gray-500 mb-6 max-w-md mx-auto">No movies have been released yet.</p>
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {visible.map((movie) => (
+                  <Link key={movie.id} href={`/movies/${movie.id}`} className="block">
+                    <MovieCard movie={movie} />
+                  </Link>
+                ))}
+              </div>
+              <div className="flex justify-between mt-8">
+                {page > 1 ? (
+                  <Link
+                    href={`/movies?page=${page - 1}`}
+                    className="px-4 py-2 text-sm bg-white border rounded-md hover:bg-gray-50"
+                  >
+                    Previous
+                  </Link>
+                ) : (
+                  <span />
+                )}
+                {hasMore && (
+                  <Link
+                    href={`/movies?page=${page + 1}`}
+                    className="px-4 py-2 text-sm bg-white border rounded-md hover:bg-gray-50"
+                  >
+                    Next
+                  </Link>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  } catch (error: any) {
+    console.error('Error loading movies:', error);
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100">
+        <div className="max-w-6xl mx-auto px-6 py-8">
           <div className="mb-8 p-6 bg-red-50 border border-red-200 rounded-xl max-w-2xl mx-auto">
             <div className="flex items-start gap-3">
               <div className="text-2xl">⚠️</div>
               <div>
                 <h3 className="font-semibold text-red-800 mb-2">Unable to Load Movies</h3>
-                <p className="text-red-700">{error}</p>
+                <p className="text-red-700">
+                  {error instanceof Error ? error.message : 'Unknown error'}
+                </p>
               </div>
             </div>
           </div>
-        )}
-
-        {!loading && movies.length === 0 && !error && (
-          <div className="text-center py-16">
-            <div className="w-24 h-24 mx-auto mb-6 opacity-30">
-              <FilmSlateIcon weight="light" size={96} className="text-gray-400" />
-            </div>
-            <h2 className="text-2xl font-semibold text-gray-700 mb-3">No Movies Yet</h2>
-            <p className="text-gray-500 mb-6 max-w-md mx-auto">
-              No movies have been released yet.
-            </p>
-          </div>
-        )}
-
-        {!loading && movies.length > 0 && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {movies.map(movie => (
-              <Link key={movie.id} href={`/movies/${movie.id}`} className="block">
-                <MovieCard movie={movie} />
-              </Link>
-            ))}
-          </div>
-        )}
+        </div>
       </div>
-    </div>
-  );
-}
-
-export default function MoviesPage() {
-  return (
-    <Suspense fallback={<div className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100" /> }>
-      <MoviesContent />
-    </Suspense>
-  );
+    );
+  }
 }

--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -1,11 +1,43 @@
 import { createClient } from '@supabase/supabase-js';
 
-export async function getClip(id: string) {
+function getClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   if (!url || !key) throw new Error('Missing Supabase configuration');
+  return createClient(url, key);
+}
 
-  const supabase = createClient(url, key);
+const deepParse = (value: any): any => {
+  if (typeof value === 'string') {
+    try {
+      return deepParse(JSON.parse(value));
+    } catch {
+      return value;
+    }
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => deepParse(v));
+  }
+  if (value && typeof value === 'object') {
+    const result: any = {};
+    for (const [k, v] of Object.entries(value)) {
+      result[k] = deepParse(v);
+    }
+    return result;
+  }
+  return value;
+};
+
+const parseAnimation = (movie: any) => {
+  const parsed = deepParse(movie.animation);
+  return {
+    ...movie,
+    animation: typeof parsed === 'object' ? parsed : null,
+  };
+};
+
+export async function getClip(id: string) {
+  const supabase = getClient();
   const { data, error } = await supabase
     .from('movies')
     .select('*')
@@ -14,3 +46,73 @@ export async function getClip(id: string) {
   if (error) throw error;
   return data;
 }
+
+export async function getAllMovies(range?: { from?: number; to?: number }) {
+  const supabase = getClient();
+  const { from = 0, to } = range || {};
+
+  let query = supabase
+    .from('movies')
+    .select(
+      `*,
+      channels!movies_channel_id_fkey(
+        id,
+        name,
+        user_id
+      )`
+    )
+    .not('publish_datetime', 'is', null)
+    .lte('publish_datetime', new Date().toISOString())
+    .order('created_at', { ascending: false });
+
+  if (typeof to === 'number') {
+    query = query.range(from, to);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    // Fallback to manual join
+    let moviesQuery = supabase
+      .from('movies')
+      .select('*')
+      .not('publish_datetime', 'is', null)
+      .lte('publish_datetime', new Date().toISOString())
+      .order('created_at', { ascending: false });
+
+    if (typeof to === 'number') {
+      moviesQuery = moviesQuery.range(from, to);
+    }
+
+    const { data: moviesData, error: moviesError } = await moviesQuery;
+
+    if (moviesError) throw moviesError;
+
+    if (!moviesData || moviesData.length === 0) {
+      return [];
+    }
+
+    const channelIds = [...new Set(moviesData.map((movie) => movie.channel_id))];
+
+    const { data: channelsData, error: channelsError } = await supabase
+      .from('channels')
+      .select('id, name, user_id')
+      .in('id', channelIds);
+
+    if (channelsError) throw channelsError;
+
+    const channelsMap = new Map(
+      (channelsData || []).map((channel) => [channel.id, channel])
+    );
+
+    return moviesData.map((movie) =>
+      parseAnimation({
+        ...movie,
+        channels: channelsMap.get(movie.channel_id) || null,
+      })
+    );
+  }
+
+  return (data || []).map(parseAnimation);
+}
+


### PR DESCRIPTION
## Summary
- fetch movies on the server in `/movies`
- add server-side pagination and error messaging
- provide a server helper to list movies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c170fa1c9483269c41251c2fe1fa79