### PR TITLE
Add orientation search param type

### DIFF
--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -10,6 +10,7 @@ interface MoviesPageProps {
     page?: string;
     category?: string;
     tag?: string;
+    orientation?: 'portrait' | 'landscape';
   };
 }
 


### PR DESCRIPTION
## Summary
- include `orientation` in movie page search params to fix TypeScript build error

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `CI=1 npm run build` *(fails: command hung, build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c5c6ec08832692602bd2fcd5c5bb